### PR TITLE
fix: bulletproof watchdog issue bodies and add Claude Code memory

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,0 +1,81 @@
+---
+description: Conventional Commits format + bump mapping. This is a single-product repo, no commit scope.
+globs:
+  - "src/**"
+  - "scripts/**"
+  - ".github/workflows/**"
+  - "package.json"
+  - "tsconfig.json"
+  - "lefthook.yml"
+  - "commitlint.config.mjs"
+---
+
+# Conventional Commits — Mandatory
+
+Every commit on `main` MUST follow [Conventional Commits](https://www.conventionalcommits.org/). release-please parses commit types to compute version bumps. Non-conventional commits are silently skipped — the watchdog (`.github/workflows/watchdog.yml`) opens an issue within 6h when this happens.
+
+## Format
+
+```
+type: subject
+```
+
+**No scope** — this is a single-product repo. Bare `feat:` / `fix:` / `chore:` is correct. Do NOT use `feat(cli): ...` — commitlint will accept it but it's inconsistent with the rest of the repo.
+
+## Valid types
+
+```
+feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
+```
+
+## Bump mapping
+
+| Commit | Bump | CHANGELOG entry |
+|---|---|---|
+| `fix: ...` | patch (1.0.0 → 1.0.1) | Yes, under "Bug Fixes" |
+| `feat: ...` | minor (1.0.0 → 1.1.0) | Yes, under "Features" |
+| `feat!: ...` or `BREAKING CHANGE:` footer | major (1.0.0 → 2.0.0) | Yes, highlighted |
+| `perf: ...` | patch | Yes, under "Performance" |
+| `revert: ...` | patch | Yes, under "Reverts" |
+| `chore:`, `docs:`, `test:`, `ci:`, `refactor:`, `build:`, `style:` | no bump | no entry |
+
+## Writing good commits
+
+- Subject in imperative: `feat: add X`, not `feat: added X` or `feat: adds X`
+- ≤72 chars subject
+- No trailing period
+- Lowercase first letter
+- Describe what the change does, not how
+
+## Examples
+
+Good:
+```
+feat: add rb batch command for parallel submissions
+fix: handle malformed checksums.txt in rb update
+feat!: rename --output flag to --out
+
+BREAKING CHANGE: --output flag renamed to --out for consistency
+```
+
+Bad:
+```
+update stuff                    ← skipped by release-please
+Feat: Added thing.              ← wrong case, past tense, trailing period
+feat(cli): add X                ← scope not used in this repo
+feat: Added a new feature.      ← past tense, capitalized, trailing period
+```
+
+## Enforcement layers
+
+1. **lefthook `commit-msg` hook** — blocks bad commit messages at `git commit` time (via commitlint)
+2. **`.github/workflows/pr-title.yml`** — required status check on PR titles (branch protection enforces)
+3. **Branch protection** on main — required `pr-title` check means bad PR titles can't merge
+4. **Watchdog cron** — catches silent skips within 6h if something slipped through
+
+## NEVER
+
+- Use `git commit --no-verify` — blocks commitlint hook. If it fails, fix the message.
+- Force-push bypassing hooks.
+- Use emoji in commit subjects (some tools choke on them).
+- Use `BREAKING CHANGE:` in the subject line — put it in a footer after a blank line.

--- a/.claude/rules/cross-repo-sdk.md
+++ b/.claude/rules/cross-repo-sdk.md
@@ -1,0 +1,67 @@
+---
+description: SDK lives in the rendobar/rendobar monorepo. Dev loop + ship order for cross-repo changes.
+globs:
+  - "src/**"
+  - "package.json"
+  - "pnpm-lock.yaml"
+  - "scripts/link-local-sdk.mjs"
+  - "scripts/unlink-local-sdk.mjs"
+  - "scripts/check-no-linked-sdk.mjs"
+---
+
+# Cross-Repo: SDK ↔ CLI
+
+The CLI depends on `@rendobar/sdk` from npm. **The SDK source is NOT in this repo.** It lives in the private [rendobar/rendobar](https://github.com/rendobar/rendobar) monorepo under `packages/sdk/`.
+
+## Where to make changes
+
+| You want to... | Edit where |
+|---|---|
+| Add a CLI command | This repo, `src/commands/` |
+| Fix a CLI bug | This repo |
+| Add an SDK method | Monorepo, `packages/sdk/src/resources/` |
+| Change SDK response types | Monorepo, `packages/shared/src/api/responses.ts` |
+| Bump SDK version used by CLI | This repo, `pnpm up @rendobar/sdk` |
+
+## Dev loop — CLI only
+
+```bash
+pnpm install
+pnpm test          # bun test, 48 tests
+pnpm typecheck     # tsc --noEmit
+pnpm dev -- --version
+pnpm build         # compile rb / rb.exe standalone
+```
+
+## Dev loop — SDK + CLI simultaneously
+
+When a CLI change needs unreleased SDK code:
+
+```bash
+# Prereq: clone monorepo as sibling directory (or set RENDOBAR_MONOREPO=/abs/path)
+#   Sibling default: ../rendobar/packages/sdk
+
+pnpm dev:sdk-local   # builds monorepo SDK, pnpm-links it here
+pnpm test            # tests now run against your local SDK
+# ...iterate...
+pnpm dev:sdk-npm     # restores @rendobar/sdk from package.json (npm version)
+```
+
+**A pre-commit hook blocks commits while the SDK is pnpm-linked.** See `scripts/check-no-linked-sdk.mjs`. The hook distinguishes normal pnpm store symlinks (safe — contain `/.pnpm/`) from dev-link targets (blocked).
+
+## Ship order
+
+When your change spans SDK + CLI:
+
+1. **Monorepo first**: commit `feat(sdk): add X API` → merge → release-please PR → merge → `sdk-vX.Y.Z` publishes to npm with provenance
+2. **Wait** 1–3 min for npm registry to propagate
+3. **This repo**: `pnpm up @rendobar/sdk@X.Y.Z` → commit `feat: use new SDK X API` → merge → release-please → ships
+
+**If you forget step 3**, the drift-check cron (`.github/workflows/drift-check.yml`, runs daily) catches it and opens an issue automatically.
+
+## Never
+
+- Commit with `@rendobar/sdk` pnpm-linked. Pre-commit hook rejects. Run `pnpm dev:sdk-npm` first.
+- Ship CLI before SDK when there's a version dependency. `pnpm install --frozen-lockfile` in CI will fail because the new SDK version doesn't exist on npm yet.
+- Use `workspace:*` protocol for `@rendobar/sdk` in package.json. This isn't a workspace. Use `^1.0.0` style versions from npm.
+- Hand-edit `node_modules/@rendobar/sdk/` to test changes — edit the monorepo source and link.

--- a/.claude/rules/release-please.md
+++ b/.claude/rules/release-please.md
@@ -1,0 +1,78 @@
+---
+description: release-please owns versions, tags, and CHANGELOG.md. Do NOT hand-edit these files.
+globs:
+  - "package.json"
+  - "CHANGELOG.md"
+  - ".release-please-manifest.json"
+  - "release-please-config.json"
+  - ".github/workflows/release-please.yml"
+  - ".github/workflows/cli-binaries.yml"
+  - "scripts/generate-version.mjs"
+---
+
+# Release-Please Owns Versioning
+
+This repo uses [release-please](https://github.com/googleapis/release-please) to automate every version bump, CHANGELOG entry, and git tag. **You do not touch any of these manually.**
+
+## Files release-please owns
+
+| File | Who writes it |
+|---|---|
+| `CHANGELOG.md` | release-please (generated from conventional commits) |
+| `package.json` → `version` field | release-please |
+| `.release-please-manifest.json` | release-please |
+| git tags (`v*`) | release-please |
+| GitHub Releases (title, body) | release-please + `cli-binaries.yml` |
+
+**If you edit any of these by hand, release-please's state diverges and the next release PR will be wrong or fail.**
+
+## Workflow
+
+```
+commit `feat: X` on main
+  ↓ release-please.yml fires
+release-please opens PR: "chore: release main" with version X+1
+  ↓ merge (branch protection requires test + lint green)
+tag vX+1 pushed
+  ↓ cli-binaries.yml fires on tag
+5 builds → attestations → GH release → 3-OS smoke test
+```
+
+**You merge two PRs per release: the feature PR, then the release-please PR.**
+
+## Forcing a version (rare)
+
+To override the computed version, add a footer to a `chore:` commit:
+
+```
+chore: prepare for 2.0.0 release
+
+Release-As: 2.0.0
+```
+
+Use this sparingly — only for first releases, rebrands, or recovering from state drift.
+
+## DO NOT
+
+- Hand-edit `CHANGELOG.md`. It's regenerated.
+- Bump `package.json` version manually. release-please does it in the release PR.
+- `git tag v1.2.3 && git push origin v1.2.3`. release-please owns tags. Manual tags corrupt its state.
+- Close release-please PRs without merging — this adds the commits to the next release with no way back.
+- Edit `src/generated/version.ts`. It's gitignored and regenerated from `package.json` by `scripts/generate-version.mjs`.
+
+## If something goes wrong
+
+1. **release-please PR is stale**: close + delete branch. Next run re-creates it.
+2. **Tag pushed but no binaries**: `cli-binaries.yml` didn't fire. Likely because release-please used `GITHUB_TOKEN` (which doesn't trigger workflows). Fix: delete the release + tag, push tag from local (`git push origin v1.2.3`) — your user PAT fires the workflow.
+3. **Wrong version computed**: add `Release-As:` footer or fix the commit that broke the bump logic.
+
+## Recovering from a broken release
+
+```bash
+# 1. Delete the bad release + tag
+gh release delete v1.2.3 --cleanup-tag --yes --repo rendobar/cli
+
+# 2. Re-tag from clean HEAD
+git tag v1.2.3 HEAD
+git push origin v1.2.3   # triggers cli-binaries.yml via user PAT
+```

--- a/.claude/rules/workflow-conventions.md
+++ b/.claude/rules/workflow-conventions.md
@@ -1,0 +1,90 @@
+---
+description: GH Actions conventions — SHA-pinned actions, Bun version, cross-platform sha256, attestations, tag behavior.
+globs:
+  - ".github/workflows/**"
+---
+
+# GitHub Actions Conventions
+
+## Action pinning — ALWAYS SHA
+
+Every `uses:` must be pinned to a full 40-char SHA, with a version comment. Tags can be moved; SHAs can't.
+
+```yaml
+# GOOD
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+# BAD — tag can be force-pushed
+- uses: actions/checkout@v4
+```
+
+**Canonical pinned SHAs for this repo** (update in lockstep if you bump any):
+
+| Action | SHA | Version |
+|---|---|---|
+| `actions/checkout` | `11bd71901bbe5b1630ceea73d27597364c9af683` | v4.2.2 |
+| `actions/setup-node` | `39370e3970a6d050c480ffad4ff0ed4d3fdee5af` | v4.1.0 |
+| `actions/upload-artifact` | `b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882` | v4.4.3 |
+| `actions/download-artifact` | `fa0a91b85d4f404e444e00e005971372dc801d16` | v4.1.8 |
+| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | v4 |
+| `actions/attest-build-provenance` | `7668571508540a607bdfd90a87a560489fe372eb` | v2.1.0 |
+| `oven-sh/setup-bun` | `4bc047ad259df6fc24a6c9b0f9a0cb08cf17fbe5` | v2.0.1 |
+| `pnpm/action-setup` | `a7487c7e89a18df4991f7f222e4898a00d66ddda` | v4.1.0 |
+| `softprops/action-gh-release` | `e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8` | v2.0.9 |
+| `googleapis/release-please-action` | `7987652d64b4581673a76e33ad5e98e3dd56832f` | v4.1.3 |
+
+Renovate auto-updates these when new versions release.
+
+## Bun version
+
+Pinned to `1.3.12` everywhere. **Do not bump without testing all 5 platforms.**
+
+- `1.2.x` is broken on `setup-bun` (HTTP 400 on download endpoint)
+- `latest` is unpredictable in CI — never use
+
+## Cross-platform SHA256
+
+Use `shasum -a 256 -c`, **never** `sha256sum -c`. The latter doesn't exist on macOS runners.
+
+```bash
+# GOOD — works on macos + linux + windows (git bash)
+shasum -a 256 -c checksums.txt
+
+# BAD — breaks on macos
+sha256sum -c checksums.txt
+```
+
+## Attestations
+
+Attestations require:
+- `permissions.attestations: write`
+- `permissions.id-token: write`  
+- `actions/attest-build-provenance` step with `subject-path:`
+- Public repository (this is one)
+
+**Do not remove `attestations: write` from `cli-binaries.yml`.** Users verify binaries with `gh attestation verify`.
+
+## Tag-triggered workflows
+
+GitHub does NOT fire workflows on tags pushed by `GITHUB_TOKEN`. This is a security feature to prevent recursive runs.
+
+- release-please pushes tags via its own auth token, which DOES fire workflows
+- If a tag is pushed manually via `GITHUB_TOKEN` (e.g., a misconfigured script), `cli-binaries.yml` will NOT fire
+- To recover: delete the tag, push it again from a local machine with a user PAT (`git push origin v1.2.3`)
+
+## Required permissions per workflow
+
+| Workflow | Permissions |
+|---|---|
+| `test.yml` | `contents: read` |
+| `pr-title.yml` | `contents: read, pull-requests: read` |
+| `release-please.yml` | `contents: write, pull-requests: write` |
+| `cli-binaries.yml` | `contents: write, id-token: write, attestations: write` |
+| `watchdog.yml` | `issues: write, contents: read, pull-requests: read` |
+| `drift-check.yml` | `issues: write, contents: read` |
+
+Set permissions at job level, not workflow level, when different jobs need different scopes.
+
+## Smoke test retry
+
+The smoke test in `cli-binaries.yml` retries 5 times with exponential backoff — GitHub's release CDN can be slow to propagate the new assets. Do not remove the retry.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,140 @@
+# AGENTS.md — rendobar-cli
+
+Guide for agents and humans working on the Rendobar CLI. Companion doc for the monorepo's `AGENTS.md` at [rendobar/rendobar](https://github.com/rendobar/rendobar).
+
+## TL;DR
+
+- **Source, tests, workflows**: all in this repo
+- **SDK source**: lives in the [rendobar/rendobar](https://github.com/rendobar/rendobar) monorepo under `packages/sdk/`. Consumed here as `@rendobar/sdk@^1.0.0` from npm.
+- **Release**: conventional commits → release-please → tag → `cli-binaries.yml` builds 5 platform binaries with attestations → GitHub Release
+- **No manual tags, no manual version bumps**
+
+## Dev loop
+
+```bash
+git clone https://github.com/rendobar/cli.git
+cd cli && pnpm install
+pnpm test          # 48 tests via bun test
+pnpm typecheck     # tsc --noEmit
+pnpm dev -- --version     # run from source
+pnpm build         # compile standalone rb / rb.exe
+./rb --version
+```
+
+## Working on SDK + CLI simultaneously
+
+When you need unreleased SDK changes in CLI:
+
+```bash
+# Prereq: clone the monorepo as a sibling (or set RENDOBAR_MONOREPO env var)
+#   ../rendobar/packages/sdk
+pnpm dev:sdk-local    # builds monorepo SDK + pnpm-links it into this repo
+pnpm test             # tests now run against your local SDK
+# ...iterate...
+pnpm dev:sdk-npm      # restores @rendobar/sdk from package.json (npm version)
+```
+
+**A pre-commit hook blocks commits while the SDK is linked.** It's automatic — if you forget to unlink, `git commit` fails with an instruction to run `pnpm dev:sdk-npm`.
+
+The sibling path is `../rendobar/packages/sdk` by default. Override via:
+
+```bash
+RENDOBAR_MONOREPO=/custom/path/to/monorepo pnpm dev:sdk-local
+```
+
+## Conventional commits
+
+Every commit on main MUST follow [Conventional Commits](https://www.conventionalcommits.org/). release-please parses them to compute version bumps. Non-conventional commits are silently skipped — the watchdog (`.github/workflows/watchdog.yml`) will open an issue within 6h if this happens.
+
+This repo is single-product: **no commit scope needed**.
+
+| Commit | Bump |
+|---|---|
+| `fix: ...` | patch (`1.0.0` → `1.0.1`) |
+| `feat: ...` | minor (`1.0.0` → `1.1.0`) |
+| `feat!: ...` or `BREAKING CHANGE:` footer | major (`1.0.0` → `2.0.0`) |
+| `chore:`, `docs:`, `test:`, `ci:`, `refactor:` | no bump, no CHANGELOG |
+
+**Force a specific version:** add `Release-As: 1.2.3` footer to a `chore:` commit.
+
+Examples:
+
+```
+feat: add rb batch command for parallel submissions
+fix: handle malformed checksums.txt in rb update
+feat!: rename --output flag to --out
+
+BREAKING CHANGE: --output is now --out
+```
+
+## Release flow (fully automated)
+
+```
+commit `feat: X` on main
+   ↓ release-please.yml fires
+release-please opens PR: "chore: release main" with bumped version
+   ↓ auto-merge (when branch protection required checks pass)
+tag v1.X.0 pushed by release-please
+   ↓ cli-binaries.yml fires on the v* tag
+5 platform builds + attestations + release + smoke tests
+   ↓
+release live at github.com/rendobar/cli/releases
+   ↓ users on older versions
+rb update → self-replaces with checksum verification + rollback
+```
+
+**You never touch tags.** Pushing a tag manually is a footgun — release-please owns them.
+
+## Guardrails already in place
+
+| Guardrail | Where | What it catches |
+|---|---|---|
+| Branch protection on `main` | GitHub settings (public repo, free) | Direct pushes, required `test` + `lint` checks before merge, linear history |
+| `commitlint` on every PR title | `.github/workflows/pr-title.yml` | Non-conventional PR titles |
+| `lefthook commit-msg` hook | `lefthook.yml` | Non-conventional local commits |
+| `lefthook pre-commit` guard | `lefthook.yml` | Committing while SDK is pnpm-linked |
+| `pnpm typecheck` + `bun test` | `.github/workflows/test.yml` | Broken code in PRs |
+| Watchdog cron (every 6h) | `.github/workflows/watchdog.yml` | Silent release skips |
+| SDK drift check cron (daily) | `.github/workflows/drift-check.yml` | Stale `@rendobar/sdk` dep vs npm latest |
+| Build provenance attestations | `.github/workflows/cli-binaries.yml` | Verify binary was built by this workflow on this commit |
+| Cross-platform smoke test | `.github/workflows/cli-binaries.yml` | Binary runs on macOS/Linux/Windows |
+
+## Verifying a released binary
+
+```bash
+# Download any release asset
+curl -fsSL -o rb.tar.gz https://github.com/rendobar/cli/releases/download/v1.0.0/rb-linux-x64.tar.gz
+
+# Verify build provenance
+gh attestation verify rb.tar.gz --repo rendobar/cli
+```
+
+Attestations prove the binary was built by this exact workflow on this exact commit, signed by GitHub's OIDC issuer.
+
+## For agents
+
+When asked to add a feature or fix a bug:
+
+1. Check `pnpm test && pnpm typecheck` is green before you touch anything
+2. Branch off `main`: `git checkout -b feat/short-name`
+3. Make changes + write tests
+4. `pnpm test && pnpm typecheck` locally
+5. Commit with a conventional message: `feat: ...` or `fix: ...`
+6. `git push -u origin <branch>` and `gh pr create --title "feat: ..."`
+7. Wait for CI green, merge
+8. Walk away — release-please handles the rest
+
+**DO NOT**:
+- Push directly to main (branch protection will reject, but don't try)
+- Push tags manually (release-please owns tags)
+- Commit while `@rendobar/sdk` is pnpm-linked (pre-commit hook rejects)
+- Edit `CHANGELOG.md` or bump `version` in `package.json` (release-please owns both)
+- Use `git commit --no-verify` (blocks hooks; investigate the hook failure instead)
+- Add a commit scope like `feat(cli): ...` (single-product repo, bare `feat:` is correct)
+
+## Gotchas
+
+- **Bun version**: pinned to `1.3.12` in all workflows. Don't bump without testing all 5 platforms.
+- **macOS sha256**: use `shasum -a 256 -c`, never `sha256sum -c` (non-existent on macOS).
+- **Tag-triggered workflows**: GitHub won't fire workflows on tags pushed by `GITHUB_TOKEN`. release-please handles this internally. If `cli-binaries.yml` doesn't fire after a release-please merge, delete the release+tag, push tag from local (user PAT triggers workflows).
+- **Attestations permission**: requires `attestations: write` in workflow permissions, separate from `id-token: write`.

--- a/scripts/drift-check.mjs
+++ b/scripts/drift-check.mjs
@@ -4,7 +4,9 @@
 // Opens a GH issue if drifted by more than a patch version.
 // Runs via .github/workflows/drift-check.yml.
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const REPO = process.env.GITHUB_REPOSITORY ?? "rendobar/cli";
 const PACKAGE = "@rendobar/sdk";
@@ -79,10 +81,16 @@ gh pr create
 
 This issue was opened automatically by \`.github/workflows/drift-check.yml\`. It will be closed automatically when the dependency is updated.`;
 
-  gh(
-    `issue create --repo ${REPO} --title "drift-check: ${PACKAGE} behind ${latest}" --body "${body.replace(/"/g, '\\"').replace(/\n/g, "\\n")}" --label dependencies --label automated`,
-  );
-  log(`opened drift issue for ${PACKAGE}: ${current} → ${latest}`);
+  const bodyFile = join(tmpdir(), `drift-check-${Date.now()}-${process.pid}.md`);
+  writeFileSync(bodyFile, body);
+  try {
+    gh(
+      `issue create --repo ${REPO} --title "drift-check: ${PACKAGE} behind ${latest}" --body-file "${bodyFile}" --label dependencies --label automated`,
+    );
+    log(`opened drift issue for ${PACKAGE}: ${current} → ${latest}`);
+  } finally {
+    try { unlinkSync(bodyFile); } catch { /* best-effort */ }
+  }
 }
 
 async function main() {

--- a/scripts/watchdog.mjs
+++ b/scripts/watchdog.mjs
@@ -4,6 +4,9 @@
 // conventional feat/fix/perf types but no open release-please PR.
 // Opens a GH issue if detected. Runs via .github/workflows/watchdog.yml.
 import { execSync } from "node:child_process";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const CONVENTIONAL_BUMP = /^(feat|fix|perf|revert)(\([a-z0-9-]+\))?!?:/;
 const REPO = process.env.GITHUB_REPOSITORY ?? "rendobar/cli";
@@ -101,13 +104,19 @@ ${commitLines}
 
 This issue was opened automatically by \`.github/workflows/watchdog.yml\`. Close it once the release PR exists.`;
 
+  // Use --body-file to avoid shell escape bugs on backticks / dollar signs
+  // in commit messages.
+  const bodyFile = join(tmpdir(), `watchdog-${Date.now()}-${process.pid}.md`);
+  writeFileSync(bodyFile, body);
   try {
     gh(
-      `issue create --repo ${REPO} --title "watchdog: silent release skip after ${tag}" --body "${body.replace(/"/g, '\\"').replace(/\n/g, "\\n")}" --label automated`,
+      `issue create --repo ${REPO} --title "watchdog: silent release skip after ${tag}" --body-file "${bodyFile}" --label automated`,
     );
     log(`opened watchdog issue for tag ${tag}`);
   } catch (err) {
     log(`failed to open issue: ${err.message}`);
+  } finally {
+    try { unlinkSync(bodyFile); } catch { /* best-effort */ }
   }
 }
 


### PR DESCRIPTION
## Summary

Audit revealed three real issues from the prior PR — fixing now.

## 1. Watchdog + drift-check issue body escaping

Both scripts used inline \`gh issue create --body \"...\"\` with manual shell escaping (\`\\\"\`, \`\n\`). Fragile: **backticks, dollar signs, and shell metacharacters in commit messages would break the command or inject shell code.**

Switched to \`gh issue create --body-file <tempfile>\`. Writes body to \`os.tmpdir()\`, unlinks after. Zero shell interpretation risk.

## 2. Add Claude Code memory (\`CLAUDE.md\` + \`.claude/rules/\`)

The prior PR added \`AGENTS.md\` but not \`CLAUDE.md\`. Claude Code auto-loads \`CLAUDE.md\` at project root — without it, future Claude sessions opened in this repo don't get any auto-loaded context.

- **\`CLAUDE.md\`** — duplicate of \`AGENTS.md\` content (both files exist; Claude reads CLAUDE.md, Codex/Cursor read AGENTS.md)
- **\`.claude/rules/release-please.md\`** — don't touch \`CHANGELOG.md\`/\`package.json\` version/tags. Recovery steps. Auto-loads on matching files.
- **\`.claude/rules/conventional-commits.md\`** — format, bump mapping, examples, enforcement layers. Explicitly: **no scope** in this single-product repo.
- **\`.claude/rules/cross-repo-sdk.md\`** — SDK source is in rendobar/rendobar, dev loop (\`dev:sdk-local\`/\`dev:sdk-npm\`), ship order.
- **\`.claude/rules/workflow-conventions.md\`** — canonical SHA-pinned action versions, Bun 1.3.12 pin, cross-platform sha256 (\`shasum\` not \`sha256sum\`), attestation permissions, tag-trigger gotcha.

## 3. Still TODO in the monorepo PR

The pre-push hook in monorepo PR #40 uses \`{branch_name}\` lefthook template, which is unreliable in pre-push context → silently exits 0 → allows all pushes. **Already fixed locally on that branch**, will force-push before merge.

## Test plan

- [x] \`pnpm typecheck\` — green
- [x] \`pnpm test\` — 48/48 passing
- [x] \`.claude/rules/\` structure matches Claude Code loader (frontmatter \`globs:\` field)
- [ ] Watchdog + drift-check will use new --body-file path on next cron run