### PR TITLE
ci: make release-please fully automatic (dispatch + PAT token)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          # PAT required so the tag release-please pushes fires cli-binaries.yml.
+          # Tags pushed by GITHUB_TOKEN do NOT trigger downstream workflows
+          # (GitHub security feature against recursive runs). Without this,
+          # release-please merges the release PR but binaries never build.
+          # Mirror of the pattern in rendobar/rendobar (commit 0df0351).
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       - name: Enable auto-merge on release PR
         if: steps.release.outputs.pr

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,11 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual escape hatch for the documented "silent release skip" failure
+  # mode (see .claude/rules/release-please.md). When label drift or a
+  # missed tag stalls release-please, a maintainer can re-fire it here
+  # without pushing a dummy commit to main.
+  workflow_dispatch: {}
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Makes the release pipeline **fully automatic on merge to main**.

Two discrete fixes, both about recovering release-please from documented failure modes:

### 1. `workflow_dispatch` escape hatch

release-please aborts future runs with *"There are untagged, merged release PRs outstanding"* when label state on a prior release PR drifts. Just hit this — PR #1 stayed labeled `autorelease: pending` after v1.0.0 shipped. Until now, recovering required pushing a dummy commit to main. Added dispatch so maintainers can re-fire release-please after fixing label state, without polluting git history.

### 2. Wire `RELEASE_PLEASE_TOKEN`

Tags pushed by `GITHUB_TOKEN` do NOT fire downstream workflows — GitHub security feature against recursive runs. Without a PAT, release-please would merge its own release PR but `cli-binaries.yml` never builds and no binaries ship. That's why v1.0.0 required the manual tag-from-local dance.

Mirrors the wiring in rendobar/rendobar (commit 0df0351).

## Required setup (repo owner)

```bash
gh secret set RELEASE_PLEASE_TOKEN --repo rendobar/cli
# paste the rendobar-cli-releases PAT value when prompted
```

PAT scopes: Contents (RW), Pull requests (RW), Workflows (RW), Metadata (R) — fine-grained, scoped to rendobar/cli.

## After merge — expected flow

```
feat: X merged to main
  ↓ release-please opens 'chore: release main' (v1.X.0)
  ↓ auto-merge kicks in (existing step, line 20-30)
  ↓ CI passes → release PR auto-merges
  ↓ release-please pushes v1.X.0 tag WITH PAT      ← key change
  ↓ cli-binaries.yml fires on v* tag
  ↓ 5 platform builds + attestations + GH release
  ↓ install.sh picks up v1.X.0 automatically
```

fix: → patch. feat: → minor. feat!: → major. No manual steps.

## Test plan

- [ ] PR CI green (test + lint)
- [ ] Repo owner sets RELEASE_PLEASE_TOKEN secret
- [ ] After merge: `gh workflow run release-please.yml --repo rendobar/cli --ref main` opens a v1.1.0 release PR (auto-merges once CI green)
- [ ] v1.1.0 tag fires cli-binaries.yml → binaries + GH release published
- [ ] `curl -fsSL https://rendobar.com/install.sh | sh` installs 1.1.0