### PR TITLE
docs: codify release discipline rules + harden release-please config

### DIFF
--- a/.claude/rules/conventional-commits.md
+++ b/.claude/rules/conventional-commits.md
@@ -1,18 +1,25 @@
 ---
-description: Conventional Commits format + bump mapping. This is a single-product repo, no commit scope.
+description: Conventional Commits format + bump mapping + release discipline. Single-product repo, no commit scope. Enforces R1-R5 (user-visible change rule, no empty releases, install scripts as public API, `!` for breaking, release-please owns tags).
 globs:
   - "src/**"
   - "scripts/**"
   - ".github/workflows/**"
+  - "install.sh"
+  - "install.ps1"
+  - "uninstall.sh"
+  - "uninstall.ps1"
   - "package.json"
   - "tsconfig.json"
   - "lefthook.yml"
   - "commitlint.config.mjs"
+  - "release-please-config.json"
+  - ".release-please-manifest.json"
+  - "CHANGELOG.md"
 ---
 
-# Conventional Commits — Mandatory
+# Conventional Commits & Release Discipline
 
-Every commit on `main` MUST follow [Conventional Commits](https://www.conventionalcommits.org/). release-please parses commit types to compute version bumps. Non-conventional commits are silently skipped — the watchdog (`.github/workflows/watchdog.yml`) opens an issue within 6h when this happens.
+Every commit on `main` MUST follow [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/). release-please parses commit types to compute version bumps. This repo is single-product — **no commit scope**.
 
 ## Format
 
@@ -20,62 +27,182 @@ Every commit on `main` MUST follow [Conventional Commits](https://www.convention
 type: subject
 ```
 
-**No scope** — this is a single-product repo. Bare `feat:` / `fix:` / `chore:` is correct. Do NOT use `feat(cli): ...` — commitlint will accept it but it's inconsistent with the rest of the repo.
+Bare `feat:` / `fix:` / `chore:` is correct. `feat(cli): ...` is rejected by rule even though commitlint accepts it — inconsistent history prevents clean grep and adds no value in a single-product repo.
 
-## Valid types
+Valid types: `feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert`.
 
-```
-feat | fix | docs | style | refactor | perf | test | build | ci | chore | revert
-```
+---
 
-## Bump mapping
+## The 5 rules that matter
 
-| Commit | Bump | CHANGELOG entry |
+### R1. `feat:` / `fix:` mean user-visible change, not "new thing in the repo"
+
+A commit is `feat:` **iff a user running `rb` (or running the install scripts) notices a new flag, subcommand, behavior, output, exit code, or install path**. Otherwise it's `chore:` / `ci:` / `build:` / `refactor:` / `docs:` / `test:`.
+
+The Conventional Commits spec grants normative meaning to `feat` (MINOR) and `fix` (PATCH) only. Everything else is team convention. The spec anchors on **consumer-observable change**, not on "did the repo gain a file."
+
+### R2. No release for commits that can't change the shipped artifact
+
+If `git diff v$PREV..HEAD -- src/ package.json install.sh install.ps1 uninstall.sh uninstall.ps1` is empty, **no release should be cut**. The binary and distribution scripts are byte-identical; shipping a new version number burns user trust, pollutes attestation audit trails, and confuses `gh release view`.
+
+Enforcement is social: pick the correct commit type (matrix below). Non-bumping types (`ci`, `chore`, `docs`, `build`, `refactor`, `test`, `style`) will not trigger release-please, so a PR with only those commits merges without cutting a release.
+
+### R3. Install scripts ARE public API
+
+`install.sh`, `install.ps1`, `uninstall.sh`, `uninstall.ps1` are distribution contracts users pipe into their shell. Breaking them ≈ breaking `rb`. Treat them as shipped code:
+
+- Add capability (new platform, new env var, new prompt) → `feat:`
+- Fix breakage (checksum regression, PATH bug, running-binary handling) → `fix:`
+- Cosmetic (log wording, comment refactor) → `chore:`
+
+### R4. Use `!` in the type for breaking changes; footer is backup
+
+Prefer `feat!: rename --output to --out` over `feat:` with `BREAKING CHANGE:` footer. Reasons:
+- `!` is visible in `git log --oneline`, in release-please's PR title, in the CHANGELOG heading
+- The footer can get lost in long squash-merge bodies
+- The spec treats them as equivalent for bump computation
+
+Only add `BREAKING CHANGE:` footer when you also need multi-line migration notes.
+
+**Never** put `BREAKING CHANGE:` in the subject line. release-please parses footers only; subject-line text is ignored and the bump will silently be wrong.
+
+### R5. release-please owns tags — manual tagging is a footgun
+
+release-please owns: `CHANGELOG.md`, `package.json` version field, `.release-please-manifest.json`, git tags, GitHub Release metadata.
+
+**Never hand-edit any of these.** They regenerate on the next run and your edit reverts.
+
+Recovery paths for state drift are documented in `release-please.md`. Do not invent ad-hoc workarounds.
+
+`GITHUB_TOKEN`-pushed tags do not trigger downstream workflows (GitHub security feature). `cli-binaries.yml` only fires when the tag is pushed by a user PAT. The `RELEASE_PLEASE_TOKEN` secret supplies this. Do not delete or overwrite it without having a replacement PAT ready.
+
+---
+
+## Decision matrix — commit type by what changed
+
+| Change | Type | Bumps? | In CHANGELOG? |
+|---|---|---|---|
+| `src/commands/*.ts` — add subcommand / flag | `feat:` | minor | yes, Features |
+| `src/**` — fix user-visible behavior | `fix:` | patch | yes, Bug Fixes |
+| `src/**` — internal rename / split / cleanup | `refactor:` | no | no |
+| `src/**` — measurable speedup (benchmark) | `perf:` | patch | yes, Performance |
+| `install.sh` / `install.ps1` — new platform, new env var | `feat:` | minor | yes |
+| `install.sh` / `install.ps1` — fix broken install | `fix:` | patch | yes |
+| `install.sh` — log wording / comment only | `chore:` | no | no |
+| `uninstall.sh` / `uninstall.ps1` — functional change | `feat:` / `fix:` | yes | yes |
+| `package.json` — runtime dep that ships in binary | `fix:` or `feat:` | yes | yes |
+| `package.json` — devDep only | `chore(deps):` | no | no |
+| `.github/workflows/**` — any change | `ci:` | no | no |
+| `scripts/*.mjs` — release/build tooling | `build:` | no | no |
+| `lefthook.yml`, `commitlint.config.mjs`, lint config | `chore:` | no | no |
+| `tsconfig.json`, `bunfig.toml` | `build:` | no | no |
+| `README.md`, `CLAUDE.md`, `AGENTS.md`, `.claude/**` | `docs:` | no | no |
+| `**/*.test.ts`, test-only | `test:` | no | no |
+| Revert a previous commit | `revert:` | patch | yes, Reverts |
+
+## Decision matrix — version bump (post-1.0)
+
+| Type | Bump | CHANGELOG section |
 |---|---|---|
-| `fix: ...` | patch (1.0.0 → 1.0.1) | Yes, under "Bug Fixes" |
-| `feat: ...` | minor (1.0.0 → 1.1.0) | Yes, under "Features" |
-| `feat!: ...` or `BREAKING CHANGE:` footer | major (1.0.0 → 2.0.0) | Yes, highlighted |
-| `perf: ...` | patch | Yes, under "Performance" |
-| `revert: ...` | patch | Yes, under "Reverts" |
-| `chore:`, `docs:`, `test:`, `ci:`, `refactor:`, `build:`, `style:` | no bump | no entry |
+| `feat!:` / `BREAKING CHANGE:` footer | **major** (1.x → 2.0) | Breaking, prominent |
+| `feat:` | minor (1.0 → 1.1) | Features |
+| `fix:` | patch (1.0.0 → 1.0.1) | Bug Fixes |
+| `perf:` | patch | Performance |
+| `revert:` | patch | Reverts |
+| `refactor:`, `docs:`, `test:`, `build:`, `ci:`, `chore:`, `style:` | none | hidden |
 
-## Writing good commits
+Pre-1.0 differs: features become patches under `bump-minor-pre-major: true`. We are post-1.0 — the pre-1.0 flags in `release-please-config.json` are `false` and must stay `false`.
 
-- Subject in imperative: `feat: add X`, not `feat: added X` or `feat: adds X`
-- ≤72 chars subject
+## Writing commit subjects
+
+- Imperative mood: `feat: add X`, not `feat: added X` / `feat: adds X`
+- ≤72 chars
 - No trailing period
 - Lowercase first letter
-- Describe what the change does, not how
+- Describe *what the change does*, not *how*
 
-## Examples
+### Good
 
-Good:
 ```
 feat: add rb batch command for parallel submissions
 fix: handle malformed checksums.txt in rb update
 feat!: rename --output flag to --out
 
-BREAKING CHANGE: --output flag renamed to --out for consistency
+BREAKING CHANGE: --output has been renamed to --out for consistency
+across the CLI. Migration: find-replace in scripts.
 ```
 
-Bad:
+### Bad
+
 ```
-update stuff                    ← skipped by release-please
+update stuff                    ← skipped by release-please (not conventional)
 Feat: Added thing.              ← wrong case, past tense, trailing period
-feat(cli): add X                ← scope not used in this repo
+feat(cli): add X                ← scope forbidden in this single-product repo
 feat: Added a new feature.      ← past tense, capitalized, trailing period
+BREAKING CHANGE: rename flag    ← footer text in subject; release-please ignores
 ```
 
-## Enforcement layers
+---
 
-1. **lefthook `commit-msg` hook** — blocks bad commit messages at `git commit` time (via commitlint)
-2. **`.github/workflows/pr-title.yml`** — required status check on PR titles (branch protection enforces)
-3. **Branch protection** on main — required `pr-title` check means bad PR titles can't merge
-4. **Watchdog cron** — catches silent skips within 6h if something slipped through
+## Anti-patterns — forbidden
+
+| Anti-pattern | Why tempting | Why wrong |
+|---|---|---|
+| Typing internal refactors as `fix:` "to document the work" | Feels productive, shows up in CHANGELOG | Cuts a patch release with no user-visible change. Use `refactor:` or `chore:`. |
+| `feat(cli): ...` scope | Copy-paste from monorepo habits | Single-product repo; inconsistent history, breaks grep, release-please doesn't use scope for bumps here. |
+| `BREAKING CHANGE:` in the subject line | Visibility | Spec violation — footer-only. release-please will not detect it, bump will be wrong. Use `!` in the type. |
+| `git tag vX.Y.Z && git push` | "Faster than waiting for release-please" | Diverges `.release-please-manifest.json`; next release-please PR computes wrong version. Also fails `cli-binaries.yml` if pushed with `GITHUB_TOKEN`. |
+| Editing `CHANGELOG.md` by hand | "Fix a typo" | Next release regenerates the file; your edit reverts. If wording matters, fix the commit message via PR description rewrite before squash-merge. |
+| Editing `package.json` `version` by hand | "Force a specific release" | release-please overwrites it. Use `Release-As: X.Y.Z` footer in a `chore:` commit. |
+| `Release-As:` to mask an empty bump | "Just get a version out" | Enshrines a lie in history. If there's no user-visible change, there's no release. |
+| Using `--no-verify` on commit | Bypass commitlint hook failure | Investigate the hook failure. Never bypass. |
+| Deleting a shipped tag/release | "Fix a bad release" | Users may be installing it via `install.sh`. Use a forward fix (revert + new release) instead. Exception: pre-adoption cleanup on a brand-new repo, documented. |
+| Consuming `/releases/latest` in user scripts without a pin option | Simplicity | `install.sh` already supports `RENDOBAR_VERSION=` env var for this reason. Keep it. |
+
+---
+
+## Commit-authoring checklist
+
+Before every commit, answer each:
+
+1. If a user runs `rb update` after this lands, will they notice **anything** different?
+   - **No** → cannot be `feat:` or `fix:`.
+2. Does the change touch `src/**` or a distribution script (`install.*` / `uninstall.*` / runtime `package.json` deps)?
+   - **No** → almost certainly `ci:` / `chore:` / `docs:` / `build:` / `test:`.
+3. Am I changing the shape of a flag, env var, subcommand, exit code, or output format?
+   - **Yes, and it removes/renames anything** → `feat!:` (breaking).
+   - **Yes, and it only adds** → `feat:`.
+4. Is this a repair of existing behavior a user already depended on?
+   - **Yes** → `fix:`.
+5. Subject line: imperative mood, ≤72 chars, no trailing period?
+6. If breaking: `!` in the type (not subject, not just footer)?
+
+If any answer is "no" or "I don't know", stop and re-read this file.
+
+---
+
+## Enforcement layers (all active)
+
+1. **lefthook `commit-msg`** — blocks bad messages locally at `git commit` time
+2. **`.github/workflows/pr-title.yml`** — required status check on PR titles
+3. **Branch protection on `main`** — required `pr-title` check means bad titles can't merge
+4. **Watchdog cron** — catches silent skips within 6h
+5. **This rule file** — source of truth for agents and humans
+
+---
 
 ## NEVER
 
-- Use `git commit --no-verify` — blocks commitlint hook. If it fails, fix the message.
+- `git commit --no-verify` — blocks commitlint. Fix the message, don't bypass.
 - Force-push bypassing hooks.
-- Use emoji in commit subjects (some tools choke on them).
-- Use `BREAKING CHANGE:` in the subject line — put it in a footer after a blank line.
+- Emojis in commit subjects (some tools choke on them).
+- `BREAKING CHANGE:` in the subject line — put it in a footer after a blank line.
+- Hand-edit CHANGELOG, package.json version, or `.release-please-manifest.json`.
+
+---
+
+## Related docs
+
+- `release-please.md` — the release flow release-please owns, recovery paths
+- `workflow-conventions.md` — Actions SHA pinning, shell rules, bun version pin
+- `cross-repo-sdk.md` — SDK + CLI ship order when changes span repos

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,18 +44,28 @@ RENDOBAR_MONOREPO=/custom/path/to/monorepo pnpm dev:sdk-local
 
 ## Conventional commits
 
-Every commit on main MUST follow [Conventional Commits](https://www.conventionalcommits.org/). release-please parses them to compute version bumps. Non-conventional commits are silently skipped — the watchdog (`.github/workflows/watchdog.yml`) will open an issue within 6h if this happens.
+Full rules + decision matrix + anti-patterns: **[.claude/rules/conventional-commits.md](.claude/rules/conventional-commits.md)** — read this before any commit.
 
-This repo is single-product: **no commit scope needed**.
+Core rules:
 
-| Commit | Bump |
+- **R1** — `feat:` / `fix:` mean *user-visible* change. Adding infra / tests / CI / docs is **not** a feat or fix.
+- **R2** — If the shipped artifact (binary + install scripts) is byte-identical to the previous release, no release. Pick a non-bumping type (`ci`, `chore`, `docs`, `build`, `refactor`, `test`).
+- **R3** — `install.sh`, `install.ps1`, `uninstall.*` are public API. Functional changes to them bump.
+- **R4** — `!` in the type for breaking changes (`feat!:`), not `BREAKING CHANGE:` in the subject.
+- **R5** — release-please owns tags, `package.json` version, `CHANGELOG.md`, and `.release-please-manifest.json`. Never hand-edit.
+
+Single-product repo — **no commit scope**. `feat:` not `feat(cli):`.
+
+Quick bump table (post-1.0):
+
+| Type | Bump |
 |---|---|
-| `fix: ...` | patch (`1.0.0` → `1.0.1`) |
-| `feat: ...` | minor (`1.0.0` → `1.1.0`) |
-| `feat!: ...` or `BREAKING CHANGE:` footer | major (`1.0.0` → `2.0.0`) |
-| `chore:`, `docs:`, `test:`, `ci:`, `refactor:` | no bump, no CHANGELOG |
+| `feat!:` / `BREAKING CHANGE:` footer | major (`1.x` → `2.0`) |
+| `feat:` | minor (`1.0` → `1.1`) |
+| `fix:`, `perf:`, `revert:` | patch (`1.0.0` → `1.0.1`) |
+| `chore:`, `docs:`, `test:`, `ci:`, `refactor:`, `build:`, `style:` | none |
 
-**Force a specific version:** add `Release-As: 1.2.3` footer to a `chore:` commit.
+**Force a specific version:** add `Release-As: X.Y.Z` footer to a `chore:` commit. Use sparingly — first releases, rebrands, recovering from state drift only.
 
 Examples:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,18 +44,28 @@ RENDOBAR_MONOREPO=/custom/path/to/monorepo pnpm dev:sdk-local
 
 ## Conventional commits
 
-Every commit on main MUST follow [Conventional Commits](https://www.conventionalcommits.org/). release-please parses them to compute version bumps. Non-conventional commits are silently skipped — the watchdog (`.github/workflows/watchdog.yml`) will open an issue within 6h if this happens.
+Full rules + decision matrix + anti-patterns: **[.claude/rules/conventional-commits.md](.claude/rules/conventional-commits.md)** — read this before any commit.
 
-This repo is single-product: **no commit scope needed**.
+Core rules:
 
-| Commit | Bump |
+- **R1** — `feat:` / `fix:` mean *user-visible* change. Adding infra / tests / CI / docs is **not** a feat or fix.
+- **R2** — If the shipped artifact (binary + install scripts) is byte-identical to the previous release, no release. Pick a non-bumping type (`ci`, `chore`, `docs`, `build`, `refactor`, `test`).
+- **R3** — `install.sh`, `install.ps1`, `uninstall.*` are public API. Functional changes to them bump.
+- **R4** — `!` in the type for breaking changes (`feat!:`), not `BREAKING CHANGE:` in the subject.
+- **R5** — release-please owns tags, `package.json` version, `CHANGELOG.md`, and `.release-please-manifest.json`. Never hand-edit.
+
+Single-product repo — **no commit scope**. `feat:` not `feat(cli):`.
+
+Quick bump table (post-1.0):
+
+| Type | Bump |
 |---|---|
-| `fix: ...` | patch (`1.0.0` → `1.0.1`) |
-| `feat: ...` | minor (`1.0.0` → `1.1.0`) |
-| `feat!: ...` or `BREAKING CHANGE:` footer | major (`1.0.0` → `2.0.0`) |
-| `chore:`, `docs:`, `test:`, `ci:`, `refactor:` | no bump, no CHANGELOG |
+| `feat!:` / `BREAKING CHANGE:` footer | major (`1.x` → `2.0`) |
+| `feat:` | minor (`1.0` → `1.1`) |
+| `fix:`, `perf:`, `revert:` | patch (`1.0.0` → `1.0.1`) |
+| `chore:`, `docs:`, `test:`, `ci:`, `refactor:`, `build:`, `style:` | none |
 
-**Force a specific version:** add `Release-As: 1.2.3` footer to a `chore:` commit.
+**Force a specific version:** add `Release-As: X.Y.Z` footer to a `chore:` commit. Use sparingly — first releases, rebrands, recovering from state drift only.
 
 Examples:
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,20 @@
   "bump-minor-pre-major": false,
   "bump-patch-for-minor-pre-major": false,
   "separate-pull-requests": false,
+  "pull-request-title-pattern": "chore: release ${version}",
+  "changelog-sections": [
+    { "type": "feat",     "section": "Features" },
+    { "type": "fix",      "section": "Bug Fixes" },
+    { "type": "perf",     "section": "Performance" },
+    { "type": "revert",   "section": "Reverts" },
+    { "type": "docs",     "section": "Documentation", "hidden": true },
+    { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+    { "type": "test",     "section": "Tests", "hidden": true },
+    { "type": "build",    "section": "Build System", "hidden": true },
+    { "type": "ci",       "section": "CI", "hidden": true },
+    { "type": "chore",    "section": "Miscellaneous", "hidden": true },
+    { "type": "style",    "section": "Style", "hidden": true }
+  ],
   "packages": {
     ".": {
       "package-name": "rendobar-cli",


### PR DESCRIPTION
## Summary

Codifies the discipline we discovered we were missing when v1.1.0 shipped as an "empty" bump (install-script PR + prior CI-only PR typed as \`fix:\` → triggered release-please → binary byte-identical to v1.0.0).

Two file updates:

### .claude/rules/conventional-commits.md — rewrite

Replaces the minimal "here are the types and bumps" doc with:
- **R1–R5**: the 5 rules that matter, each with the failure mode it prevents
- **Decision matrix**: commit type by what-file-changed (src, install scripts, workflows, docs, etc.)
- **Decision matrix**: version bump by commit type, post-1.0
- **Anti-patterns**: 10 forbidden moves with the reason each is tempting and why it's wrong
- **Pre-commit checklist**: 6 questions to stop and answer before every commit
- **NEVER** section: \`--no-verify\`, hand-edits, emoji, subject-line \`BREAKING CHANGE:\`

Key rule that would have prevented v1.1.0: **R1** — \`feat:\` / \`fix:\` mean *user-visible change*, not "new thing in the repo." PR #3's \`fix: bulletproof watchdog...\` touched only \`.github/workflows/watchdog.yml\` and should have been \`ci:\`. That alone would have prevented a version bump.

### release-please-config.json — hardened

Two adds:

1. \`pull-request-title-pattern: "chore: release \${version}"\` — removes the stray \`(main)\` component, clean PR titles.
2. Explicit \`changelog-sections\` with \`hidden: true\` on ci/chore/docs/build/refactor/test/style. Belt-and-suspenders — default behavior mostly matches, but this makes it auditable and prevents a future release-please default change from silently polluting the CHANGELOG.

Intentionally **not** adding \`include-paths\`. It scopes commit *parsing* (not just bump filtering), so a \`feat:\` touching both \`src/\` and a workflow wouldn't filter correctly. R1+R2 discipline at commit-authoring time is safer.

### AGENTS.md / CLAUDE.md

Replaced the bump table with an R1–R5 summary and a link into the full rules file. They remain byte-identical to each other.

## Research basis

Audited against [astral-sh/uv](https://github.com/astral-sh/uv/releases) (user-visible-only CHANGELOG discipline), [cli/cli](https://github.com/cli/cli/releases), [denoland/deno](https://github.com/denoland/deno/releases), and the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) + [release-please config schema](https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json) specs.

## No release expected

This is a \`docs:\` commit per R1's own definition — no bump, no CHANGELOG entry. It's the first commit under the new rules, and the rules predict themselves correctly.

## Follow-up

Separate PR will reset release state to a clean v1.0.0 (delete existing v1.0.0 + v1.1.0 tags/releases, reset manifest, \`Release-As: 1.0.0\`). Safe because adoption is zero (~12h since v1.1.0, no stable install channels caching it). That PR lands only after this one merges.

## Test plan

- [ ] PR CI green (test + lint + pr-title)
- [ ] Merge — verify release-please does NOT open a release PR (rule self-validation)
- [ ] Follow-up reset PR proceeds