### PR TITLE
fix: use RUNNER_TEMP in install-scripts Windows live-mode path

### DIFF
--- a/.github/workflows/install-scripts.yml
+++ b/.github/workflows/install-scripts.yml
@@ -246,12 +246,16 @@ jobs:
         shell: bash
         run: |
           set -eu
+          # Windows: use RUNNER_TEMP (Windows-native path) rather than /tmp.
+          # Git-bash understands /tmp but PowerShell (which runs the test steps)
+          # doesn't, and a cross-shell handoff needs a path both can open.
+          TMP="${RUNNER_TEMP}/rdbr"
+          mkdir -p "$TMP"
           if [ "${{ steps.mode.outputs.mode }}" = "live" ]; then
-            mkdir -p /tmp/rdbr
-            curl -fsSL --retry 3 --retry-delay 2 https://rendobar.com/install.ps1   -o /tmp/rdbr/install.ps1
-            curl -fsSL --retry 3 --retry-delay 2 https://rendobar.com/uninstall.ps1 -o /tmp/rdbr/uninstall.ps1
-            echo "install=/tmp/rdbr/install.ps1"     >> "$GITHUB_OUTPUT"
-            echo "uninstall=/tmp/rdbr/uninstall.ps1" >> "$GITHUB_OUTPUT"
+            curl -fsSL --retry 3 --retry-delay 2 https://rendobar.com/install.ps1   -o "$TMP/install.ps1"
+            curl -fsSL --retry 3 --retry-delay 2 https://rendobar.com/uninstall.ps1 -o "$TMP/uninstall.ps1"
+            echo "install=$TMP/install.ps1"     >> "$GITHUB_OUTPUT"
+            echo "uninstall=$TMP/uninstall.ps1" >> "$GITHUB_OUTPUT"
           else
             echo "install=${GITHUB_WORKSPACE}/install.ps1"     >> "$GITHUB_OUTPUT"
             echo "uninstall=${GITHUB_WORKSPACE}/uninstall.ps1" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Windows job's 'Resolve script paths' step wrote `/tmp/rdbr/install.ps1` to GITHUB_OUTPUT. Git-bash on windows-latest resolves `/tmp` internally, but PowerShell — which runs the test steps — sees the literal path and errors:

```
The term '/tmp/rdbr/install.ps1' is not recognized as the name of a
cmdlet, function, script file, or operable program.
```

This broke live-mode install-scripts runs (cron + release + workflow_dispatch live). Confirmed by today's post-v1.0.0 dispatch (run #24889153687).

## Fix

Use `$RUNNER_TEMP` which resolves to a Windows-native path (`D:\a\_temp`) on windows-latest and a POSIX path on unix-latest. Cross-shell safe.

Unix job unchanged — `/tmp` works there.

## Test plan

- [ ] PR CI (branch-mode) green
- [ ] After merge: workflow_dispatch with source=live runs green on both Windows shells