### PR TITLE
chore: standardize metadata + brand-consistency rules across repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://rendobar.com/docs
+    url: https://rendobar.com/docs/
     about: Guides, API reference, examples
   - name: Website
     url: https://rendobar.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,69 @@ Guide for agents and humans working on the Rendobar CLI. Companion doc for the m
 - **Release**: conventional commits → release-please → tag → `cli-binaries.yml` builds 5 platform binaries with attestations → GitHub Release
 - **No manual tags, no manual version bumps**
 
+---
+
+## Cross-repo brand consistency
+
+This repo is part of the broader Rendobar platform. The canonical reference
+for brand strings, URLs, OG metadata, robots policy, and title/description
+rules across **every** rendobar repo lives in the apex monorepo at
+`rendobar/rendobar` `.claude/rules/brand-consistency.md`:
+
+https://github.com/rendobar/rendobar/blob/main/.claude/rules/brand-consistency.md
+
+Critical rules embedded here so you don't need to context-switch:
+
+### Canonical brand strings (must match apex)
+
+| Field | Value |
+|---|---|
+| Display name | `Rendobar` |
+| Apex URL | `https://rendobar.com` |
+| Apex page URLs | `https://rendobar.com/<path>/` (always trailing slash) |
+| API URL | `https://api.rendobar.com` |
+| Dashboard URL | `https://app.rendobar.com` |
+| CDN URL | `https://cdn.rendobar.com` |
+| Twitter handle | `@rendobar` |
+
+**Forbidden variants**: `Rendobar.com`, `the Rendobar platform`, `rendobar`
+(lowercase except in URLs / package names), `https://www.rendobar.com`,
+`http://rendobar.com`, apex page links without a trailing slash.
+
+### `package.json description` — em-dash, sentence case
+
+- ✅ `"Rendobar CLI — serverless video processing from your terminal."`
+- ❌ `"Rendobar | CLI Tool"` (pipe, title case)
+- ❌ `"Rendobar CLI - serverless..."` (ASCII hyphen instead of em-dash)
+
+### README + issue templates — trailing slash on apex page links
+
+Apex Astro is configured with `trailingSlash: "always"`. Every link to an
+`https://rendobar.com/<path>` page **must end with `/`**:
+- ✅ `https://rendobar.com/docs/`, `https://rendobar.com/blog/`, `https://rendobar.com/pricing/`
+- ❌ `https://rendobar.com/docs`, `https://rendobar.com/blog`
+
+The apex root (`https://rendobar.com`) and subdomain roots
+(`https://api.rendobar.com`, `https://app.rendobar.com`,
+`https://cdn.rendobar.com`) are file/origin URLs and stay slash-less.
+
+The install scripts at `https://rendobar.com/install.sh` etc. are FILES, not
+pages — they correctly stay slash-less.
+
+### No AI attribution in commits / PRs
+
+Per the user's global rule (also in apex): never add `Co-Authored-By: Claude`,
+`🤖 Generated with [Claude Code]`, or any AI attribution in commit messages or
+PR descriptions. Strip them silently if a template injects them.
+
+### Anti-patterns — never do these
+
+- Use a brand-string variant other than canonical `Rendobar`
+- Use `Rendobar | ...` (pipe) or `Rendobar - ...` (ASCII hyphen) in package.json description
+- Skip the trailing slash on a `https://rendobar.com/<path>` link in README, issue templates, install scripts that print URLs, or workflow files
+- Reference `rendobar.com/blog`, `rendobar.com/pricing`, `rendobar.com/docs` without trailing slash
+- Add a `Co-Authored-By: Claude` or "Generated with [Claude Code]" line in commit messages or PR descriptions
+
 ## Dev loop
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,69 @@ Guide for agents and humans working on the Rendobar CLI. Companion doc for the m
 - **Release**: conventional commits → release-please → tag → `cli-binaries.yml` builds 5 platform binaries with attestations → GitHub Release
 - **No manual tags, no manual version bumps**
 
+---
+
+## Cross-repo brand consistency
+
+This repo is part of the broader Rendobar platform. The canonical reference
+for brand strings, URLs, OG metadata, robots policy, and title/description
+rules across **every** rendobar repo lives in the apex monorepo at
+`rendobar/rendobar` `.claude/rules/brand-consistency.md`:
+
+https://github.com/rendobar/rendobar/blob/main/.claude/rules/brand-consistency.md
+
+Critical rules embedded here so you don't need to context-switch:
+
+### Canonical brand strings (must match apex)
+
+| Field | Value |
+|---|---|
+| Display name | `Rendobar` |
+| Apex URL | `https://rendobar.com` |
+| Apex page URLs | `https://rendobar.com/<path>/` (always trailing slash) |
+| API URL | `https://api.rendobar.com` |
+| Dashboard URL | `https://app.rendobar.com` |
+| CDN URL | `https://cdn.rendobar.com` |
+| Twitter handle | `@rendobar` |
+
+**Forbidden variants**: `Rendobar.com`, `the Rendobar platform`, `rendobar`
+(lowercase except in URLs / package names), `https://www.rendobar.com`,
+`http://rendobar.com`, apex page links without a trailing slash.
+
+### `package.json description` — em-dash, sentence case
+
+- ✅ `"Rendobar CLI — serverless video processing from your terminal."`
+- ❌ `"Rendobar | CLI Tool"` (pipe, title case)
+- ❌ `"Rendobar CLI - serverless..."` (ASCII hyphen instead of em-dash)
+
+### README + issue templates — trailing slash on apex page links
+
+Apex Astro is configured with `trailingSlash: "always"`. Every link to an
+`https://rendobar.com/<path>` page **must end with `/`**:
+- ✅ `https://rendobar.com/docs/`, `https://rendobar.com/blog/`, `https://rendobar.com/pricing/`
+- ❌ `https://rendobar.com/docs`, `https://rendobar.com/blog`
+
+The apex root (`https://rendobar.com`) and subdomain roots
+(`https://api.rendobar.com`, `https://app.rendobar.com`,
+`https://cdn.rendobar.com`) are file/origin URLs and stay slash-less.
+
+The install scripts at `https://rendobar.com/install.sh` etc. are FILES, not
+pages — they correctly stay slash-less.
+
+### No AI attribution in commits / PRs
+
+Per the user's global rule (also in apex): never add `Co-Authored-By: Claude`,
+`🤖 Generated with [Claude Code]`, or any AI attribution in commit messages or
+PR descriptions. Strip them silently if a template injects them.
+
+### Anti-patterns — never do these
+
+- Use a brand-string variant other than canonical `Rendobar`
+- Use `Rendobar | ...` (pipe) or `Rendobar - ...` (ASCII hyphen) in package.json description
+- Skip the trailing slash on a `https://rendobar.com/<path>` link in README, issue templates, install scripts that print URLs, or workflow files
+- Reference `rendobar.com/blog`, `rendobar.com/pricing`, `rendobar.com/docs` without trailing slash
+- Add a `Co-Authored-By: Claude` or "Generated with [Claude Code]" line in commit messages or PR descriptions
+
 ## Dev loop
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 <p align="center">
   <a href="https://rendobar.com">Website</a> •
-  <a href="https://rendobar.com/docs">Docs</a> •
+  <a href="https://rendobar.com/docs/">Docs</a> •
   <a href="https://www.npmjs.com/package/@rendobar/sdk">SDK</a> •
   <a href="https://github.com/rendobar/cli/releases/latest">Latest Release</a>
 </p>
@@ -77,7 +77,7 @@ rb ffmpeg -i input.mp4 -vf "drawtext=text='PREVIEW':fontsize=48:fontcolor=white@
 rb --help
 ```
 
-Full usage: [rendobar.com/docs/cli](https://rendobar.com/docs/cli)
+Full usage: [rendobar.com/docs/cli/](https://rendobar.com/docs/cli/)
 
 ## Auto-update
 
@@ -94,7 +94,7 @@ Self-replaces the binary in-place with checksum verification and automatic rollb
 Rendobar is a serverless media processing platform — watermark, transcode, caption, render videos with one API call. Credit-based billing. MCP-native for AI agents.
 
 - **Website**: https://rendobar.com
-- **Docs**: https://rendobar.com/docs
+- **Docs**: https://rendobar.com/docs/
 - **API**: https://api.rendobar.com
 - **SDK**: [@rendobar/sdk](https://www.npmjs.com/package/@rendobar/sdk) on npm
 
@@ -133,7 +133,7 @@ Commit messages must follow [Conventional Commits](https://www.conventionalcommi
 
 - **Bugs**: [open an issue](https://github.com/rendobar/cli/issues/new?template=bug.md)
 - **Feature requests**: [open an issue](https://github.com/rendobar/cli/issues/new?template=feature.md)
-- **Docs**: https://rendobar.com/docs
+- **Docs**: https://rendobar.com/docs/
 - **Contact**: hello@rendobar.com
 
 ## License


### PR DESCRIPTION
## Summary

Aligns this repo with the cross-rendobar brand-consistency standard rolled out in the apex monorepo ([rendobar/rendobar PR #85](https://github.com/rendobar/rendobar/pull/85)) and the docs site ([rendobar/docs PR #4](https://github.com/rendobar/docs/pull/4)). No source code changes — only README, issue template, and agent docs.

## What changed

### Trailing-slash fixes on apex page links

Apex Astro is configured with `trailingSlash: "always"`. Every link from this repo to an `https://rendobar.com/<path>` page should end with `/` to match the canonical URLs the apex emits:

| File | Before | After |
|---|---|---|
| README.md (header) | `rendobar.com/docs` | `rendobar.com/docs/` |
| README.md ("Full usage") | `rendobar.com/docs/cli` | `rendobar.com/docs/cli/` |
| README.md ("What is Rendobar" + Support) | 2× `rendobar.com/docs` | 2× `rendobar.com/docs/` |
| .github/ISSUE_TEMPLATE/config.yml | `rendobar.com/docs` | `rendobar.com/docs/` |

Install/uninstall script URLs (`rendobar.com/install.sh`, `install.ps1`, `uninstall.sh`, `uninstall.ps1`) are FILES, not pages — they correctly stay slash-less.

### `CLAUDE.md` + `AGENTS.md` — new "Cross-repo brand consistency" section

Both files now reference the apex `.claude/rules/brand-consistency.md` as the canonical source of truth, and embed the critical rules locally so an agent (Claude Code, Cursor, etc.) working in this repo doesn't need to context-switch. Embedded:

- Canonical brand strings table (Rendobar, https://rendobar.com, https://api.rendobar.com, etc.)
- Forbidden brand-string variants (`Rendobar.com`, `the Rendobar platform`, etc.)
- `package.json description` rules — em-dash, sentence case
- README + issue-template trailing-slash rule
- No AI attribution in commits / PRs (`Co-Authored-By: Claude`, "Generated with [Claude Code]")
- Anti-patterns list

`CLAUDE.md` and `AGENTS.md` were already kept in sync — both updated identically.

## Why this PR exists

Without a written rule, the `rendobar.com/docs` (no trailing slash) drift will keep recurring every time someone updates a link. The new section in `CLAUDE.md` / `AGENTS.md` makes the convention explicit so any future agent edit conforms automatically.

## Verification

- [x] `package.json description` already em-dash + sentence case (no change needed)
- [x] All apex page links in README + issue templates now have trailing slash
- [x] `homepage` field unchanged (`https://rendobar.com` — apex root, slash-less)
- [x] Install script URLs unchanged (files, not pages)
- [x] No code changes; no version bump

## Related PRs

- [rendobar/rendobar #85](https://github.com/rendobar/rendobar/pull/85) — apex metadata standardization + new `.claude/rules/brand-consistency.md`
- [rendobar/docs #4](https://github.com/rendobar/docs/pull/4) — Mintlify docs metadata + `CLAUDE.md`