### PR TITLE
fix: locate running binary via execPath instead of argv[0]

### DIFF
--- a/src/__tests__/bin-path.test.ts
+++ b/src/__tests__/bin-path.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "bun:test";
+import { getBinPath } from "../lib/bin-path.js";
+
+describe("getBinPath", () => {
+  it("returns process.execPath (the real executable), not argv[0]", () => {
+    // In a compiled Bun binary, process.argv[0] is the literal "bun" while
+    // process.execPath is the actual rb.exe path. We must use execPath.
+    expect(getBinPath()).toBe(process.execPath);
+  });
+
+  it("never returns the bare runtime name 'bun'", () => {
+    expect(getBinPath()).not.toBe("bun");
+  });
+
+  it("returns a non-empty path", () => {
+    expect(getBinPath().length).toBeGreaterThan(0);
+  });
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import { defineCommand } from "citty";
 import { VERSION } from "../generated/version.js";
 import { getConfigDir } from "../lib/auth.js";
+import { getBinPath } from "../lib/bin-path.js";
 
 // Compile-time defines from `bun build --compile --define`. In dev mode they're undefined.
 declare const IS_STANDALONE: boolean | undefined;
@@ -263,7 +264,7 @@ async function checkGhRateLimit(): Promise<Check> {
 }
 
 export async function runDoctor(opts: { json?: boolean; fix?: boolean } = {}): Promise<void> {
-  const binPath = process.argv[0] ?? "";
+  const binPath = getBinPath();
   const checks: Check[] = [
     await checkVersion(),
     checkInstallMethod(),

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -9,6 +9,7 @@ import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { defineCommand } from "citty";
 import { VERSION } from "../generated/version.js";
+import { getBinPath } from "../lib/bin-path.js";
 
 // Compile-time defines from `bun build --compile --define`. In dev mode they're undefined.
 declare const IS_STANDALONE: boolean | undefined;
@@ -100,11 +101,6 @@ async function downloadArchive(tag: string, archiveName: string): Promise<Uint8A
 
 function sha256(data: Uint8Array): string {
   return createHash("sha256").update(data).digest("hex");
-}
-
-function getBinPath(): string {
-  // argv[0] in a compiled bun binary is the binary path
-  return process.argv[0] ?? "";
 }
 
 function isSameVersion(latest: string): boolean {

--- a/src/lib/bin-path.ts
+++ b/src/lib/bin-path.ts
@@ -1,0 +1,14 @@
+/**
+ * Absolute path to the currently-running `rb` executable.
+ *
+ * In a Bun single-file executable (`bun build --compile`), `process.execPath`
+ * is the compiled binary itself (the `rb` / `rb.exe`). `process.argv[0]` is the
+ * embedded runtime name — the literal string `"bun"` — and must NOT be used:
+ * doing so broke `rb update` ("cannot locate current binary at bun") and the
+ * macOS quarantine check, which both need the real on-disk path.
+ *
+ * Verified on a compiled binary: execPath → "<dir>/rb.exe", argv[0] → "bun".
+ */
+export function getBinPath(): string {
+  return process.execPath || "";
+}


### PR DESCRIPTION
## Summary
`rb update` failed on standalone binaries with **`Update failed: cannot locate current binary at bun`**. In a Bun single-file executable, `process.argv[0]` is the literal string `"bun"` (the embedded runtime name), not the executable path — so `existsSync(binPath)` failed before any download. The macOS quarantine check in `rb doctor` resolved the path the same buggy way.

Fix: resolve the running executable via `process.execPath` (the compiled binary path) through a shared `getBinPath()` helper, used by both `update` and `doctor`.

## Verification
- Probe on a compiled Bun binary: `process.execPath` → `…/rb.exe`, `process.argv[0]` → `"bun"`.
- **End-to-end on a `windows-x64` standalone build** (with `IS_STANDALONE`/`PLATFORM` defines): a 0.9.0-stamped fixed binary ran `rb update` → located itself → downloaded `rb-windows-x64.zip` → checksum verified → `.new`/`.bak` swap → post-swap `--version` check passed → exit 0.
- `pnpm test` 105 pass / 0 fail; `pnpm typecheck` clean.

## Note for existing users
Binaries already installed at ≤ 1.0.1 still carry the broken `rb update`, so they can't self-update to this fix. They must re-run the installer **once** (`iwr https://rendobar.com/install.ps1 -useb | iex` / `curl -fsSL https://rendobar.com/install.sh | sh`); subsequent `rb update`s work normally.

## Test plan
- [x] Unit: `getBinPath()` returns `process.execPath`, never `"bun"`
- [x] E2E: full Windows update flow on a standalone build
- [ ] Confirm on macOS/Linux standalone after release (tar.gz path)
