### PR TITLE
ci: make releases fully automatic via explicit tag step

### DIFF
--- a/.claude/rules/release-please.md
+++ b/.claude/rules/release-please.md
@@ -21,8 +21,8 @@ This repo uses [release-please](https://github.com/googleapis/release-please) to
 | `CHANGELOG.md` | release-please (generated from conventional commits) |
 | `package.json` → `version` field | release-please |
 | `.release-please-manifest.json` | release-please |
-| git tags (`v*`) | release-please |
-| GitHub Releases (title, body) | release-please + `cli-binaries.yml` |
+| git tags (`v*`) | `release-please.yml` Tag step (PAT push) — see "How tagging works" below |
+| GitHub Releases (title, body) | `cli-binaries.yml` (on the tag) |
 
 **If you edit any of these by hand, release-please's state diverges and the next release PR will be wrong or fail.**
 
@@ -32,11 +32,37 @@ This repo uses [release-please](https://github.com/googleapis/release-please) to
 commit `feat: X` on main
   ↓ release-please.yml fires
 release-please opens PR: "chore: release main" with version X+1
-  ↓ merge (branch protection requires test + lint green)
-tag vX+1 pushed
-  ↓ cli-binaries.yml fires on tag
+  ↓ auto-merge enabled with the PAT (squash, once test+lint green)
+release PR squash-merges → push to main re-fires release-please.yml
+  ↓ "Tag released version" step: pushes vX+1 (PAT) + labels PR `autorelease: tagged`
+cli-binaries.yml fires on the vX+1 tag
+  ↓
 5 builds → attestations → GH release → 3-OS smoke test
 ```
+
+You merge **only the feature PR**. The release PR auto-merges and tags itself.
+
+## How tagging works (and why release-please does NOT create the release)
+
+`release-please.yml` sets `skip-github-release: true`. release-please therefore
+manages only the version PR, `CHANGELOG.md`, and the manifest — it does **not**
+create the GitHub Release or push the tag itself.
+
+Reason: release-please's github-release step cannot match this single-root-package
+repo's merged release PR. In v16.12.0, `getBranchComponent()` resolves to the
+package name (`rendobar-cli`) while the merged PR branch (`release-please--branches--main`)
+carries no component, so the components mismatch, the release is skipped, and the
+PR is left `autorelease: pending` forever — which then aborts every later run
+(`"untagged, merged release PRs outstanding"`). This is upstream bug
+googleapis/release-please#2214 (open for root paths); `component: ""` does not fix
+it (`"" || getDefaultComponent()` falls back to the package name).
+
+Instead, the **"Tag released version"** step in `release-please.yml` runs after a
+release PR merges: it reads the version from `package.json`, pushes `vX.Y.Z` with
+the PAT (so `cli-binaries.yml` fires), and flips the merged PR to
+`autorelease: tagged` to clear the bookkeeping. The PAT (`RELEASE_PLEASE_TOKEN`) is
+also what enables auto-merge, so the release-PR merge re-triggers the workflow —
+a `GITHUB_TOKEN` merge would fire nothing.
 
 **You merge two PRs per release: the feature PR, then the release-please PR.**
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,26 +16,76 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Needed by the "Tag released version" step below (git tag + push).
+      # Uses the PAT so the pushed tag triggers cli-binaries.yml — tags pushed
+      # by GITHUB_TOKEN do NOT fire downstream workflows.
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
       - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f  # v4.1.3
         id: release
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          # PAT required so the tag release-please pushes fires cli-binaries.yml.
-          # Tags pushed by GITHUB_TOKEN do NOT trigger downstream workflows
-          # (GitHub security feature against recursive runs). Without this,
-          # release-please merges the release PR but binaries never build.
-          # Mirror of the pattern in rendobar/rendobar (commit 0df0351).
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          # release-please's own github-release step cannot match this
+          # single-root-package repo's merged release PR: getBranchComponent()
+          # resolves to the package name ("rendobar-cli") while the merged PR
+          # branch carries no component, so it skips the release and never tags
+          # (upstream bug googleapis/release-please#2214, open for root paths).
+          # We therefore let release-please manage only the version PR +
+          # CHANGELOG + manifest, and create the tag ourselves below.
+          skip-github-release: true
 
+      # When release-please opens/updates a release PR, auto-merge it once the
+      # required checks pass. Uses the PAT (not GITHUB_TOKEN) so the eventual
+      # squash-merge to main re-triggers this workflow — otherwise the merge
+      # push is attributed to github-actions[bot] and fires nothing.
       - name: Enable auto-merge on release PR
         if: steps.release.outputs.pr
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           PR_NUMBER=$(echo '${{ steps.release.outputs.pr }}' | node -e "
             let d = '';
             process.stdin.on('data', c => d += c);
             process.stdin.on('end', () => console.log(JSON.parse(d).number));
           ")
-          gh pr merge "$PR_NUMBER" --auto --squash --repo ${{ github.repository }} || true
+          gh pr merge "$PR_NUMBER" --auto --squash --repo "${{ github.repository }}" || true
+
+      # When a release PR has just merged (no new PR opened this run), push the
+      # tag so cli-binaries.yml builds + publishes, and flip the merged PR's
+      # label to 'autorelease: tagged' so release-please stops treating it as an
+      # outstanding untagged release (which would otherwise jam every future run).
+      - name: Tag released version
+        if: ${{ !steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          SUBJECT=$(git log -1 --pretty=%s)
+          case "$SUBJECT" in
+            "chore: release"*) ;;
+            *) echo "HEAD is not a release commit ('$SUBJECT') — nothing to tag."; exit 0 ;;
+          esac
+
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v$VERSION"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "$TAG already exists — nothing to do."
+            exit 0
+          fi
+
+          echo "Tagging $TAG at $(git rev-parse --short HEAD)"
+          git tag "$TAG"
+          git push origin "$TAG"   # PAT-authenticated push fires cli-binaries.yml
+
+          # Clear the release-please bookkeeping label on the merged release PR.
+          PR=$(printf '%s' "$SUBJECT" | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+          if [ -n "$PR" ]; then
+            gh pr edit "$PR" \
+              --repo "${{ github.repository }}" \
+              --remove-label "autorelease: pending" \
+              --add-label "autorelease: tagged" || true
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,8 +146,9 @@ BREAKING CHANGE: --output is now --out
 commit `feat: X` on main
    ↓ release-please.yml fires
 release-please opens PR: "chore: release main" with bumped version
-   ↓ auto-merge (when branch protection required checks pass)
-tag v1.X.0 pushed by release-please
+   ↓ release PR auto-merges (PAT, squash) once test+lint pass
+tag v1.X.0 pushed by release-please.yml's Tag step (release-please's own
+   github-release is skipped — see .claude/rules/release-please.md)
    ↓ cli-binaries.yml fires on the v* tag
 5 platform builds + attestations + release + smoke tests
    ↓

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,8 +146,9 @@ BREAKING CHANGE: --output is now --out
 commit `feat: X` on main
    ↓ release-please.yml fires
 release-please opens PR: "chore: release main" with bumped version
-   ↓ auto-merge (when branch protection required checks pass)
-tag v1.X.0 pushed by release-please
+   ↓ release PR auto-merges (PAT, squash) once test+lint pass
+tag v1.X.0 pushed by release-please.yml's Tag step (release-please's own
+   github-release is skipped — see .claude/rules/release-please.md)
    ↓ cli-binaries.yml fires on the v* tag
 5 platform builds + attestations + release + smoke tests
    ↓


### PR DESCRIPTION
## Problem
Releases have never been automatic. Both v1.0.1 (#11) and v1.1.0 (#17) merged, bumped the manifest, then sat **un-released** at `autorelease: pending` — and every later run aborted with `untagged, merged release PRs outstanding`.

**Root cause (confirmed in pinned release-please v16.12.0):** release-please's github-release step can't match this single-root-package repo's merged release PR. `getBranchComponent()` returns `this.component || getDefaultComponent()` → the package name **`rendobar-cli`**, while the merged PR branch `release-please--branches--main` carries **no** component. `"" !== "rendobar-cli"` → the release is skipped, never tagged. This is upstream bug [googleapis/release-please#2214](https://github.com/googleapis/release-please/issues/2214) (open for root paths). `component: ""` does **not** fix it — `"" || getDefaultComponent()` falls back to the package name.

Compounding it: the auto-merge step ran as `GITHUB_TOKEN`, so even when a release PR merged, the push didn't re-trigger the workflow (GitHub doesn't fire workflows on `GITHUB_TOKEN` pushes).

## Fix
Stop fighting the buggy component matcher — take release creation out of release-please's hands:

1. **`skip-github-release: true`** — release-please manages only the version PR, `CHANGELOG.md`, and the manifest.
2. **Auto-merge with the PAT** (`RELEASE_PLEASE_TOKEN`, not `GITHUB_TOKEN`) so the release-PR squash-merge re-fires the workflow.
3. **New "Tag released version" step** — on a release-commit merge, reads the version from `package.json`, pushes `vX.Y.Z` with the PAT (which fires `cli-binaries.yml`), and flips the merged PR to `autorelease: tagged` so release-please stops treating it as outstanding.

Net: **merge a feature PR → release ships end-to-end, no manual steps.**

## Validation
- `release-please.yml` parses (YAML OK, 4 steps); all tokens use the PAT; action SHA-pinned per repo convention.
- Logic verified against release-please v16.12.0 source (`getBranchComponent`/`getComponent`/`getDefaultComponent`).
- Full validation requires one live release cycle (workflow changes can't run locally).

## One-time cleanup (separate from this PR)
v1.1.0 (#17) is already merged under the old flow, so it still needs a manual tag once:
`git tag v1.1.0 38bf00a && git push origin v1.1.0` (PAT), then relabel #17 `autorelease: tagged`. After that, this workflow handles every future release automatically.

## Test plan
- [x] YAML valid, tokens correct, SHA-pinned
- [x] Component bug + fix traced in pinned source
- [ ] Confirm on the next real release cycle (feature PR → auto release)
