### PR TITLE
feat: submit ffmpeg job type instead of raw.ffmpeg

### DIFF
--- a/src/__tests__/shell-escape.test.ts
+++ b/src/__tests__/shell-escape.test.ts
@@ -157,7 +157,7 @@ describe("shellEscape", () => {
     // to "" — but our parser drops empty quoted segments via the
     // `current.length > 0` push gate. That's a known/accepted limitation:
     // ffmpeg never takes empty argv elements and the CLI never produces them
-    // for raw.ffmpeg. Filter the empty out before comparing.
+    // for ffmpeg. Filter the empty out before comparing.
     expect(parse(command)).toEqual(argv.filter((a) => a.length > 0));
   });
 });

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -164,7 +164,7 @@ export default defineCommand({
 
       const job = await steps.step("Submitting", async () => {
         return client.jobs.create(
-          { type: "raw.ffmpeg", params: { command, timeout: flags.timeout } },
+          { type: "ffmpeg", params: { command, timeout: flags.timeout } },
           { signal: controller.signal },
         );
       });

--- a/src/lib/shell-escape.ts
+++ b/src/lib/shell-escape.ts
@@ -1,7 +1,7 @@
 /**
  * POSIX shell-escape an argv element for embedding in a single command string.
  *
- * Used when the CLI joins argv into a `command` field for `raw.ffmpeg` job
+ * Used when the CLI joins argv into a `command` field for `ffmpeg` job
  * submission. The API-side parser implements the matching POSIX rules so
  * `argv → shellEscape → join → parse → argv` is lossless.
  *


### PR DESCRIPTION
Submits job type `ffmpeg` instead of `raw.ffmpeg`.

The API now uses `ffmpeg` as the canonical job type (rendobar/rendobar#197). The backend still accepts `raw.ffmpeg` as a transitional alias, so this is non-breaking. No SDK dependency bump needed — `CreateJobParams.type` is a free-form string.

## Test plan
- `pnpm test` — 105 pass
- `pnpm typecheck` — clean