### PR TITLE
ci: attach demo files to release directly instead of zipping

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -45,17 +45,18 @@ jobs:
           path: demos/out/
           retention-days: 30
 
-      - name: Bundle for release
-        if: startsWith(github.ref, 'refs/tags/v')
-        run: |
-          cd demos/out
-          zip -r ../../demos.zip .
-
+      # Attach the rendered media straight to the release. The vhs container
+      # (debian:stable-slim) ships no `zip`, and bundling 3 files into an
+      # archive nobody can preview adds no value -- hero.gif renders inline on
+      # the release page, the mp4/webm download as-is.
       - name: Attach to release
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda  # v3.0.0
         with:
-          files: demos.zip
+          files: |
+            demos/out/hero.gif
+            demos/out/hero.mp4
+            demos/out/hero.webm
 
       - name: Drift check (main branch)
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Problem

The `demos` workflow fails on tag builds:

```
/__w/_temp/...sh: 2: zip: not found
Error: Process completed with exit code 127.
```

The `Bundle for release` step runs `cd demos/out && zip -r ../../demos.zip .` inside the VHS container (`ghcr.io/charmbracelet/vhs:v0.11.0`). That image's final stage is `debian:stable-slim`, which ships no `zip` binary — hence exit 127. The step only runs on `v*` tags, so it stayed hidden until the first tagged release.

## Fix

Drop the zip step entirely and attach the rendered media straight to the GitHub Release via `softprops/action-gh-release`'s `files:` list.

`demos/out/` after render is exactly three files — `hero.gif` (tracked), `hero.mp4` + `hero.webm` (gitignored, regenerated). Bundling three files into an archive nobody can preview added no value. Direct attach:

- removes the root cause (no `zip` dependency)
- adds **zero** new deps — no `apt-get install` + debian-mirror round-trip on every tag
- `hero.gif` now previews inline on the release page; mp4/webm download as-is

## Alternative considered

`apt-get update && apt-get install -y zip` (root user, so no sudo) would keep a single `demos.zip`. Rejected: a network install on every release to bundle 3 previewable files is strictly worse than attaching them directly.

## Test plan

- [ ] Cut a `v*` tag (or re-run the failed release) and confirm the `Attach to release` step uploads all three assets.
- [x] YAML committed verbatim, byte-verified on branch.