### PR TITLE
feat: show served multi-file output and ffmpeg errorDetail

### DIFF
--- a/src/__tests__/progress.test.ts
+++ b/src/__tests__/progress.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { buildResult } from "../lib/progress.js";
+import { buildResult, servedEntryUrl } from "../lib/progress.js";
 
 describe("buildResult — served output + errorDetail", () => {
   it("reads a single-file outputUrl", () => {
@@ -67,5 +67,28 @@ describe("buildResult — served output + errorDetail", () => {
   it("leaves errorDetail undefined when absent", () => {
     const r = buildResult("failed", undefined, { errorMessage: "Job failed" });
     expect(r.errorDetail).toBeUndefined();
+  });
+});
+
+describe("servedEntryUrl", () => {
+  it("prefers the stream entry url when present", () => {
+    expect(
+      servedEntryUrl({
+        type: "stream",
+        url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
+        baseUrl: "https://api.rendobar.com/v/job_1/tok/",
+        fileCount: 7,
+      }),
+    ).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
+  });
+
+  it("falls back to the base url for a set (no entry url)", () => {
+    expect(
+      servedEntryUrl({
+        type: "set",
+        baseUrl: "https://api.rendobar.com/v/job_2/tok/",
+        fileCount: 120,
+      }),
+    ).toBe("https://api.rendobar.com/v/job_2/tok/");
   });
 });

--- a/src/__tests__/progress.test.ts
+++ b/src/__tests__/progress.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "bun:test";
+import { buildResult } from "../lib/progress.js";
+
+describe("buildResult — served output + errorDetail", () => {
+  it("reads a single-file outputUrl", () => {
+    const r = buildResult("complete", undefined, {
+      outputUrl: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+    });
+    expect(r.outputUrl).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
+    expect(r.output).toBeUndefined();
+  });
+
+  it("captures a served stream output (HLS playlist)", () => {
+    const r = buildResult("complete", undefined, {
+      outputUrl: null,
+      output: {
+        type: "stream",
+        url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
+        playlist: "master.m3u8",
+        baseUrl: "https://api.rendobar.com/v/job_1/tok/",
+        expiresAt: 123,
+        fileCount: 7,
+        files: [],
+        manifestUrl: "https://api.rendobar.com/v/job_1/tok/_manifest.json",
+      },
+    });
+    expect(r.outputUrl).toBeUndefined();
+    expect(r.output?.type).toBe("stream");
+    expect(r.output?.url).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
+    expect(r.output?.fileCount).toBe(7);
+  });
+
+  it("captures a served set output (no entry url)", () => {
+    const r = buildResult("complete", undefined, {
+      outputUrl: null,
+      output: {
+        type: "set",
+        baseUrl: "https://api.rendobar.com/v/job_2/tok/",
+        expiresAt: 123,
+        fileCount: 120,
+        files: [],
+        manifestUrl: "https://api.rendobar.com/v/job_2/tok/_manifest.json",
+      },
+    });
+    expect(r.output?.type).toBe("set");
+    expect(r.output?.url).toBeUndefined();
+    expect(r.output?.baseUrl).toBe("https://api.rendobar.com/v/job_2/tok/");
+    expect(r.output?.fileCount).toBe(120);
+  });
+
+  it("ignores a malformed output object", () => {
+    const r = buildResult("complete", undefined, {
+      output: { type: "bogus", baseUrl: 42 },
+    });
+    expect(r.output).toBeUndefined();
+  });
+
+  it("surfaces errorDetail (ffmpeg stderr tail) on failure", () => {
+    const r = buildResult("failed", undefined, {
+      errorMessage: "Job failed",
+      errorDetail: "frame= 100\n[error] Conversion failed!",
+    });
+    expect(r.error).toBe("Job failed");
+    expect(r.errorDetail).toContain("Conversion failed!");
+  });
+
+  it("leaves errorDetail undefined when absent", () => {
+    const r = buildResult("failed", undefined, { errorMessage: "Job failed" });
+    expect(r.errorDetail).toBeUndefined();
+  });
+});

--- a/src/__tests__/progress.test.ts
+++ b/src/__tests__/progress.test.ts
@@ -1,5 +1,8 @@
-import { describe, it, expect } from "bun:test";
-import { buildResult, outputUrl } from "../lib/progress.js";
+import { describe, it, expect, afterEach } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { buildResult, outputUrl, downloadUrlToFile, downloadFilesToDir, type JobFile } from "../lib/progress.js";
 
 describe("buildResult — unified output", () => {
   it("reads a file output (headline file + meta)", () => {
@@ -170,5 +173,126 @@ describe("outputUrl", () => {
     expect(
       outputUrl({ data: { ok: true }, file: null, files: [], expiresAt: null }),
     ).toBeUndefined();
+  });
+});
+
+// ── Local download (behaves like a local tool) ─────────────────
+
+describe("downloadUrlToFile — single file to a named local path", () => {
+  const realFetch = globalThis.fetch;
+  let tmpDir: string;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function mockBody(map: Record<string, string>): void {
+    globalThis.fetch = ((input: unknown) => {
+      const url = String(input);
+      const body = map[url];
+      if (body === undefined) return Promise.resolve(new Response("not found", { status: 404 }));
+      return Promise.resolve(new Response(body, { status: 200 }));
+    }) as typeof globalThis.fetch;
+  }
+
+  it("fetches the signed url and writes to the exact local path", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-dl-"));
+    mockBody({ "https://signed.example/out.mp4": "VIDEO_BYTES" });
+
+    const target = path.join(tmpDir, "out.mp4");
+    await downloadUrlToFile("https://signed.example/out.mp4", target);
+
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.readFileSync(target, "utf8")).toBe("VIDEO_BYTES");
+  });
+
+  it("throws on a non-ok response", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-dl-"));
+    mockBody({});
+    await expect(
+      downloadUrlToFile("https://signed.example/missing.mp4", path.join(tmpDir, "x.mp4")),
+    ).rejects.toThrow();
+  });
+});
+
+describe("downloadFilesToDir — set/stream into a local folder", () => {
+  const realFetch = globalThis.fetch;
+  let tmpDir: string;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    if (tmpDir) fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function mockBody(map: Record<string, string>): void {
+    globalThis.fetch = ((input: unknown) => {
+      const url = String(input);
+      const body = map[url];
+      if (body === undefined) return Promise.resolve(new Response("not found", { status: 404 }));
+      return Promise.resolve(new Response(body, { status: 200 }));
+    }) as typeof globalThis.fetch;
+  }
+
+  it("downloads every file of a set, preserving each path", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-set-"));
+    const files: JobFile[] = [
+      { url: "https://signed.example/a.png", path: "a.png", type: "image", size: 1 },
+      { url: "https://signed.example/b.png", path: "b.png", type: "image", size: 1 },
+    ];
+    mockBody({ "https://signed.example/a.png": "A", "https://signed.example/b.png": "B" });
+
+    const written = await downloadFilesToDir(files, tmpDir);
+
+    expect(written.length).toBe(2);
+    expect(fs.readFileSync(path.join(tmpDir, "a.png"), "utf8")).toBe("A");
+    expect(fs.readFileSync(path.join(tmpDir, "b.png"), "utf8")).toBe("B");
+  });
+
+  it("downloads a stream manifest + segments so it plays locally", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-hls-"));
+    const files: JobFile[] = [
+      { url: "https://signed.example/master.m3u8", path: "master.m3u8", type: "playlist", size: 1 },
+      { url: "https://signed.example/seg0.ts", path: "seg0.ts", type: "video", size: 1 },
+      { url: "https://signed.example/seg1.ts", path: "seg1.ts", type: "video", size: 1 },
+    ];
+    mockBody({
+      "https://signed.example/master.m3u8": "#EXTM3U",
+      "https://signed.example/seg0.ts": "S0",
+      "https://signed.example/seg1.ts": "S1",
+    });
+
+    const written = await downloadFilesToDir(files, tmpDir);
+
+    expect(written.length).toBe(3);
+    expect(fs.readFileSync(path.join(tmpDir, "master.m3u8"), "utf8")).toBe("#EXTM3U");
+    expect(fs.existsSync(path.join(tmpDir, "seg0.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "seg1.ts"))).toBe(true);
+  });
+
+  it("preserves nested relative paths and creates subdirs", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-nested-"));
+    const files: JobFile[] = [
+      { url: "https://signed.example/v/720p/seg0.ts", path: "720p/seg0.ts", type: "video", size: 1 },
+    ];
+    mockBody({ "https://signed.example/v/720p/seg0.ts": "NESTED" });
+
+    const written = await downloadFilesToDir(files, tmpDir);
+
+    expect(written.length).toBe(1);
+    expect(fs.readFileSync(path.join(tmpDir, "720p", "seg0.ts"), "utf8")).toBe("NESTED");
+  });
+
+  it("falls back to the url basename when a file has no path", async () => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-nopath-"));
+    const files: JobFile[] = [
+      { url: "https://signed.example/cdn/frame_001.png", path: "", type: "image", size: 1 },
+    ];
+    mockBody({ "https://signed.example/cdn/frame_001.png": "PNG" });
+
+    const written = await downloadFilesToDir(files, tmpDir);
+
+    expect(written.length).toBe(1);
+    expect(fs.readFileSync(path.join(tmpDir, "frame_001.png"), "utf8")).toBe("PNG");
   });
 });

--- a/src/__tests__/progress.test.ts
+++ b/src/__tests__/progress.test.ts
@@ -1,68 +1,96 @@
 import { describe, it, expect } from "bun:test";
 import { buildResult, outputUrl } from "../lib/progress.js";
 
-describe("buildResult — discriminated output", () => {
-  it("reads a file output (download url + meta)", () => {
+describe("buildResult — unified output", () => {
+  it("reads a file output (headline file + meta)", () => {
     const r = buildResult("complete", undefined, {
       output: {
-        kind: "file",
-        url: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+        data: null,
+        file: {
+          url: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+          path: "output.mp4",
+          type: "video",
+          size: 4096,
+          meta: { format: "mp4", width: 1280, height: 720 },
+        },
+        files: [
+          {
+            url: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+            path: "output.mp4",
+            type: "video",
+            size: 4096,
+            meta: { format: "mp4", width: 1280, height: 720 },
+          },
+        ],
         expiresAt: 123,
-        poster: null,
-        meta: { format: "mp4", width: 1280, height: 720, sizeBytes: 4096 },
       },
     });
-    expect(r.output?.kind).toBe("file");
-    if (r.output?.kind === "file") {
-      expect(r.output.url).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
-      expect(r.output.poster).toBeNull();
-      expect(r.output.meta.width).toBe(1280);
-    }
+    expect(r.output?.data).toBeNull();
+    expect(r.output?.file?.url).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
+    expect(r.output?.file?.type).toBe("video");
+    expect(r.output?.file?.meta?.width).toBe(1280);
+    expect(r.output?.files.length).toBe(1);
+    expect(r.output?.expiresAt).toBe(123);
     expect(r.error).toBeUndefined();
   });
 
-  it("reads a stream output (HLS playlist)", () => {
+  it("reads a stream output (playlist headline file)", () => {
     const r = buildResult("complete", undefined, {
       output: {
-        kind: "stream",
-        url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
-        manifest: "hls",
-        baseUrl: "https://api.rendobar.com/v/job_1/tok/",
+        data: null,
+        file: {
+          url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
+          path: "master.m3u8",
+          type: "playlist",
+          size: 512,
+        },
+        files: [
+          { url: "https://api.rendobar.com/v/job_1/tok/seg0.ts", path: "seg0.ts", type: "video", size: 1000 },
+          { url: "https://api.rendobar.com/v/job_1/tok/seg1.ts", path: "seg1.ts", type: "video", size: 1000 },
+        ],
         expiresAt: 123,
-        fileCount: 7,
-        files: [],
-        manifestUrl: "https://api.rendobar.com/v/job_1/tok/_manifest.json",
       },
     });
-    expect(r.output?.kind).toBe("stream");
-    if (r.output?.kind === "stream") {
-      expect(r.output.url).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
-      expect(r.output.manifest).toBe("hls");
-      expect(r.output.fileCount).toBe(7);
-    }
+    expect(r.output?.file?.type).toBe("playlist");
+    expect(r.output?.file?.url).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
+    expect(r.output?.files.length).toBe(2);
   });
 
-  it("reads a set output (no entry url)", () => {
+  it("reads a set output (no headline file, multiple files)", () => {
     const r = buildResult("complete", undefined, {
       output: {
-        kind: "set",
-        baseUrl: "https://api.rendobar.com/v/job_2/tok/",
+        data: null,
+        file: null,
+        files: [
+          { url: "https://api.rendobar.com/v/job_2/tok/a.png", path: "a.png", type: "image", size: 100 },
+          { url: "https://api.rendobar.com/v/job_2/tok/b.png", path: "b.png", type: "image", size: 100 },
+        ],
         expiresAt: 123,
-        fileCount: 120,
-        files: [],
-        manifestUrl: "https://api.rendobar.com/v/job_2/tok/_manifest.json",
       },
     });
-    expect(r.output?.kind).toBe("set");
-    if (r.output?.kind === "set") {
-      expect(r.output.baseUrl).toBe("https://api.rendobar.com/v/job_2/tok/");
-      expect(r.output.fileCount).toBe(120);
-    }
+    expect(r.output?.file).toBeNull();
+    expect(r.output?.files.length).toBe(2);
+    expect(r.output?.files[0]?.path).toBe("a.png");
   });
 
-  it("ignores a malformed output object", () => {
+  it("reads a data-only output (data non-null, no files)", () => {
     const r = buildResult("complete", undefined, {
-      output: { kind: "bogus", baseUrl: 42 },
+      output: {
+        data: { duration: 12.5, streams: 2 },
+        file: null,
+        files: [],
+        expiresAt: null,
+      },
+    });
+    expect(r.output?.data).toEqual({ duration: 12.5, streams: 2 });
+    expect(r.output?.file).toBeNull();
+    expect(r.output?.files.length).toBe(0);
+    expect(r.output?.expiresAt).toBeNull();
+  });
+
+  it("ignores a malformed output object (no files array)", () => {
+    const r = buildResult("complete", undefined, {
+      output: { data: null, file: null },
     });
     expect(r.output).toBeUndefined();
   });
@@ -102,38 +130,45 @@ describe("buildResult — discriminated output", () => {
 });
 
 describe("outputUrl", () => {
-  it("returns the download url for a file", () => {
+  it("returns the headline file url for a single file", () => {
     expect(
       outputUrl({
-        kind: "file",
-        url: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
-        poster: null,
-        meta: {},
+        data: null,
+        file: { url: "https://cdn.rendobar.com/jobs/job_1/output.mp4", path: "output.mp4", type: "video", size: 1 },
+        files: [{ url: "https://cdn.rendobar.com/jobs/job_1/output.mp4", path: "output.mp4", type: "video", size: 1 }],
+        expiresAt: null,
       }),
     ).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
   });
 
-  it("returns the entry playlist for a stream", () => {
+  it("returns the manifest url for a stream", () => {
     expect(
       outputUrl({
-        kind: "stream",
-        url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
-        manifest: "hls",
-        baseUrl: "https://api.rendobar.com/v/job_1/tok/",
-        fileCount: 7,
-        manifestUrl: "https://api.rendobar.com/v/job_1/tok/_manifest.json",
+        data: null,
+        file: { url: "https://api.rendobar.com/v/job_1/tok/master.m3u8", path: "master.m3u8", type: "playlist", size: 1 },
+        files: [{ url: "https://api.rendobar.com/v/job_1/tok/seg0.ts", path: "seg0.ts", type: "video", size: 1 }],
+        expiresAt: null,
       }),
     ).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
   });
 
-  it("falls back to the base url for a set (no entry url)", () => {
+  it("falls back to the first file url for a set (no headline file)", () => {
     expect(
       outputUrl({
-        kind: "set",
-        baseUrl: "https://api.rendobar.com/v/job_2/tok/",
-        fileCount: 120,
-        manifestUrl: "https://api.rendobar.com/v/job_2/tok/_manifest.json",
+        data: null,
+        file: null,
+        files: [
+          { url: "https://api.rendobar.com/v/job_2/tok/a.png", path: "a.png", type: "image", size: 1 },
+          { url: "https://api.rendobar.com/v/job_2/tok/b.png", path: "b.png", type: "image", size: 1 },
+        ],
+        expiresAt: null,
       }),
-    ).toBe("https://api.rendobar.com/v/job_2/tok/");
+    ).toBe("https://api.rendobar.com/v/job_2/tok/a.png");
+  });
+
+  it("returns undefined for a data-only output (no files)", () => {
+    expect(
+      outputUrl({ data: { ok: true }, file: null, files: [], expiresAt: null }),
+    ).toBeUndefined();
   });
 });

--- a/src/__tests__/progress.test.ts
+++ b/src/__tests__/progress.test.ts
@@ -1,22 +1,32 @@
 import { describe, it, expect } from "bun:test";
-import { buildResult, servedEntryUrl } from "../lib/progress.js";
+import { buildResult, outputUrl } from "../lib/progress.js";
 
-describe("buildResult — served output + errorDetail", () => {
-  it("reads a single-file outputUrl", () => {
+describe("buildResult — discriminated output", () => {
+  it("reads a file output (download url + meta)", () => {
     const r = buildResult("complete", undefined, {
-      outputUrl: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+      output: {
+        kind: "file",
+        url: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+        expiresAt: 123,
+        poster: null,
+        meta: { format: "mp4", width: 1280, height: 720, sizeBytes: 4096 },
+      },
     });
-    expect(r.outputUrl).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
-    expect(r.output).toBeUndefined();
+    expect(r.output?.kind).toBe("file");
+    if (r.output?.kind === "file") {
+      expect(r.output.url).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
+      expect(r.output.poster).toBeNull();
+      expect(r.output.meta.width).toBe(1280);
+    }
+    expect(r.error).toBeUndefined();
   });
 
-  it("captures a served stream output (HLS playlist)", () => {
+  it("reads a stream output (HLS playlist)", () => {
     const r = buildResult("complete", undefined, {
-      outputUrl: null,
       output: {
-        type: "stream",
+        kind: "stream",
         url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
-        playlist: "master.m3u8",
+        manifest: "hls",
         baseUrl: "https://api.rendobar.com/v/job_1/tok/",
         expiresAt: 123,
         fileCount: 7,
@@ -24,17 +34,18 @@ describe("buildResult — served output + errorDetail", () => {
         manifestUrl: "https://api.rendobar.com/v/job_1/tok/_manifest.json",
       },
     });
-    expect(r.outputUrl).toBeUndefined();
-    expect(r.output?.type).toBe("stream");
-    expect(r.output?.url).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
-    expect(r.output?.fileCount).toBe(7);
+    expect(r.output?.kind).toBe("stream");
+    if (r.output?.kind === "stream") {
+      expect(r.output.url).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
+      expect(r.output.manifest).toBe("hls");
+      expect(r.output.fileCount).toBe(7);
+    }
   });
 
-  it("captures a served set output (no entry url)", () => {
+  it("reads a set output (no entry url)", () => {
     const r = buildResult("complete", undefined, {
-      outputUrl: null,
       output: {
-        type: "set",
+        kind: "set",
         baseUrl: "https://api.rendobar.com/v/job_2/tok/",
         expiresAt: 123,
         fileCount: 120,
@@ -42,52 +53,86 @@ describe("buildResult — served output + errorDetail", () => {
         manifestUrl: "https://api.rendobar.com/v/job_2/tok/_manifest.json",
       },
     });
-    expect(r.output?.type).toBe("set");
-    expect(r.output?.url).toBeUndefined();
-    expect(r.output?.baseUrl).toBe("https://api.rendobar.com/v/job_2/tok/");
-    expect(r.output?.fileCount).toBe(120);
+    expect(r.output?.kind).toBe("set");
+    if (r.output?.kind === "set") {
+      expect(r.output.baseUrl).toBe("https://api.rendobar.com/v/job_2/tok/");
+      expect(r.output.fileCount).toBe(120);
+    }
   });
 
   it("ignores a malformed output object", () => {
     const r = buildResult("complete", undefined, {
-      output: { type: "bogus", baseUrl: 42 },
+      output: { kind: "bogus", baseUrl: 42 },
     });
     expect(r.output).toBeUndefined();
   });
 
-  it("surfaces errorDetail (ffmpeg stderr tail) on failure", () => {
-    const r = buildResult("failed", undefined, {
-      errorMessage: "Job failed",
-      errorDetail: "frame= 100\n[error] Conversion failed!",
-    });
-    expect(r.error).toBe("Job failed");
-    expect(r.errorDetail).toContain("Conversion failed!");
+  it("leaves output undefined when absent", () => {
+    const r = buildResult("complete", undefined, {});
+    expect(r.output).toBeUndefined();
   });
 
-  it("leaves errorDetail undefined when absent", () => {
-    const r = buildResult("failed", undefined, { errorMessage: "Job failed" });
-    expect(r.errorDetail).toBeUndefined();
+  it("surfaces a structured error (code + message + detail) on failure", () => {
+    const r = buildResult("failed", undefined, {
+      error: {
+        code: "PROVIDER_ERROR",
+        message: "Job failed",
+        detail: "frame= 100\n[error] Conversion failed!",
+        retryable: false,
+      },
+    });
+    expect(r.error?.code).toBe("PROVIDER_ERROR");
+    expect(r.error?.message).toBe("Job failed");
+    expect(r.error?.detail).toContain("Conversion failed!");
+    expect(r.error?.retryable).toBe(false);
+  });
+
+  it("defaults error.detail to null when absent", () => {
+    const r = buildResult("failed", undefined, {
+      error: { code: "TIMEOUT", message: "Job failed", retryable: true },
+    });
+    expect(r.error?.detail).toBeNull();
+    expect(r.error?.retryable).toBe(true);
+  });
+
+  it("ignores a malformed error object", () => {
+    const r = buildResult("failed", undefined, { error: { message: 42 } });
+    expect(r.error).toBeUndefined();
   });
 });
 
-describe("servedEntryUrl", () => {
-  it("prefers the stream entry url when present", () => {
+describe("outputUrl", () => {
+  it("returns the download url for a file", () => {
     expect(
-      servedEntryUrl({
-        type: "stream",
+      outputUrl({
+        kind: "file",
+        url: "https://cdn.rendobar.com/jobs/job_1/output.mp4",
+        poster: null,
+        meta: {},
+      }),
+    ).toBe("https://cdn.rendobar.com/jobs/job_1/output.mp4");
+  });
+
+  it("returns the entry playlist for a stream", () => {
+    expect(
+      outputUrl({
+        kind: "stream",
         url: "https://api.rendobar.com/v/job_1/tok/master.m3u8",
+        manifest: "hls",
         baseUrl: "https://api.rendobar.com/v/job_1/tok/",
         fileCount: 7,
+        manifestUrl: "https://api.rendobar.com/v/job_1/tok/_manifest.json",
       }),
     ).toBe("https://api.rendobar.com/v/job_1/tok/master.m3u8");
   });
 
   it("falls back to the base url for a set (no entry url)", () => {
     expect(
-      servedEntryUrl({
-        type: "set",
+      outputUrl({
+        kind: "set",
         baseUrl: "https://api.rendobar.com/v/job_2/tok/",
         fileCount: 120,
+        manifestUrl: "https://api.rendobar.com/v/job_2/tok/_manifest.json",
       }),
     ).toBe("https://api.rendobar.com/v/job_2/tok/");
   });

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -8,7 +8,7 @@ import { homedir, platform, arch } from "node:os";
 import { spawnSync } from "node:child_process";
 import { defineCommand } from "citty";
 import { VERSION } from "../generated/version.js";
-import { getConfigDir } from "../lib/auth.js";
+import { getConfigDir, getApiBaseUrl } from "../lib/auth.js";
 import { getBinPath } from "../lib/bin-path.js";
 
 // Compile-time defines from `bun build --compile --define`. In dev mode they're undefined.
@@ -134,15 +134,17 @@ function checkUpdateCache(): Check {
 }
 
 async function checkApiReachable(): Promise<Check> {
+  const baseUrl = getApiBaseUrl();
+  const host = (() => { try { return new URL(baseUrl).host; } catch { return baseUrl; } })();
   try {
-    const res = await fetchWithTimeout("https://api.rendobar.com/health");
+    const res = await fetchWithTimeout(`${baseUrl}/health`);
     if (res.ok) {
-      return { name: "api.rendobar.com", status: "ok", detail: `HTTP ${res.status}` };
+      return { name: host, status: "ok", detail: `HTTP ${res.status}` };
     }
-    return { name: "api.rendobar.com", status: "warn", detail: `HTTP ${res.status}` };
+    return { name: host, status: "warn", detail: `HTTP ${res.status}` };
   } catch (err) {
     return {
-      name: "api.rendobar.com",
+      name: host,
       status: "fail",
       detail: (err as Error).message,
       fix: "Check your internet connection or status.rendobar.com",

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -13,7 +13,7 @@ import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl } from "../lib/auth.js
 import { parseFfmpegArgs } from "../lib/parse-ffmpeg-args.js";
 import { shellEscape } from "../lib/shell-escape.js";
 import { uploadLocalFiles } from "../lib/upload.js";
-import { StepRenderer, waitForJob, downloadOutput, type MachineContext } from "../lib/progress.js";
+import { StepRenderer, waitForJob, downloadOutput, servedEntryUrl, type MachineContext } from "../lib/progress.js";
 
 function fmtMs(ms: number): string {
   if (ms < 100) return `${ms}ms`;
@@ -245,7 +245,7 @@ export default defineCommand({
       if (flags.urlOnly) {
         // Served multi-file jobs have no single outputUrl; fall back to the
         // served entry URL (stream playlist) when present.
-        const url = result.outputUrl ?? result.output?.url ?? result.output?.baseUrl;
+        const url = result.outputUrl ?? (result.output && servedEntryUrl(result.output));
         if (url) console.log(url);
         process.exit(0);
       }
@@ -264,7 +264,7 @@ export default defineCommand({
       } else if (result.output && !flags.quiet && isTTY) {
         // Served multi-file output: no single file to save. Show the served
         // entry URL plus how many files sit under the prefix.
-        const servedUrl = result.output.url ?? result.output.baseUrl;
+        const servedUrl = servedEntryUrl(result.output);
         const fileLabel = result.output.fileCount === 1 ? "file" : "files";
         process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(servedUrl)}\n`);
         process.stderr.write(`    ${pc.dim(`${result.output.fileCount} ${fileLabel}`)}\n`);

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -13,7 +13,7 @@ import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl } from "../lib/auth.js
 import { parseFfmpegArgs } from "../lib/parse-ffmpeg-args.js";
 import { shellEscape } from "../lib/shell-escape.js";
 import { uploadLocalFiles } from "../lib/upload.js";
-import { StepRenderer, waitForJob, downloadOutput, servedEntryUrl, type MachineContext } from "../lib/progress.js";
+import { StepRenderer, waitForJob, downloadOutput, outputUrl, type MachineContext } from "../lib/progress.js";
 
 function fmtMs(ms: number): string {
   if (ms < 100) return `${ms}ms`;
@@ -228,10 +228,12 @@ export default defineCommand({
       if (result.status === "failed") {
         if (flags.json) console.log(JSON.stringify(result));
         else if (!flags.quiet) {
-          steps.info(pc.red(`✗ ${result.error ?? "Job failed"}`));
+          const err = result.error;
+          const headline = err ? `${err.code}: ${err.message}` : "Job failed";
+          steps.info(pc.red(`✗ ${headline}`));
           // Surface the ffmpeg stderr tail so failures are debuggable in-place.
-          if (result.errorDetail) {
-            for (const line of result.errorDetail.trimEnd().split("\n")) {
+          if (err?.detail) {
+            for (const line of err.detail.trimEnd().split("\n")) {
               steps.info(pc.dim(line));
             }
           }
@@ -243,31 +245,39 @@ export default defineCommand({
       // ── Output modes ─────────────────────────────────────
       if (flags.json) { console.log(JSON.stringify(result)); process.exit(0); }
       if (flags.urlOnly) {
-        // Served multi-file jobs have no single outputUrl; fall back to the
-        // served entry URL (stream playlist) when present.
-        const url = result.outputUrl ?? (result.output && servedEntryUrl(result.output));
-        if (url) console.log(url);
+        // file/stream → playable url; set → prefix base url.
+        if (result.output) console.log(outputUrl(result.output));
         process.exit(0);
       }
 
       // ── 4. Download output ───────────────────────────────
-      if (parsed.outputFile && result.outputUrl) {
+      const out = result.output;
+      if (parsed.outputFile && out?.kind === "file") {
         const outputPath = path.resolve(parsed.outputFile);
         await steps.step("Saving", async () => {
           return downloadOutput(client, job.id, outputPath);
         });
 
         if (!flags.quiet && isTTY) {
-          process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(parsed.outputFile)}\n`);
+          const dims = out.meta.width && out.meta.height ? ` ${pc.dim(`${out.meta.width}×${out.meta.height}`)}` : "";
+          process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(parsed.outputFile)}${dims}\n`);
           process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
         }
-      } else if (result.output && !flags.quiet && isTTY) {
-        // Served multi-file output: no single file to save. Show the served
-        // entry URL plus how many files sit under the prefix.
-        const servedUrl = servedEntryUrl(result.output);
-        const fileLabel = result.output.fileCount === 1 ? "file" : "files";
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(servedUrl)}\n`);
-        process.stderr.write(`    ${pc.dim(`${result.output.fileCount} ${fileLabel}`)}\n`);
+      } else if (out?.kind === "file" && !flags.quiet && isTTY) {
+        // Single output, no local file requested: print its download URL.
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(out.url)}\n`);
+        process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
+      } else if (out?.kind === "stream" && !flags.quiet && isTTY) {
+        // HLS/DASH stream: print the playable entry playlist + file count.
+        const fileLabel = out.fileCount === 1 ? "file" : "files";
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(out.url)}\n`);
+        process.stderr.write(`    ${pc.dim(`${out.manifest.toUpperCase()} · ${out.fileCount} ${fileLabel}`)}\n`);
+        process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
+      } else if (out?.kind === "set" && !flags.quiet && isTTY) {
+        // Unordered multi-file set: no entry url, print the prefix base + count.
+        const fileLabel = out.fileCount === 1 ? "file" : "files";
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(out.baseUrl)}\n`);
+        process.stderr.write(`    ${pc.dim(`${out.fileCount} ${fileLabel}`)}\n`);
         process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
       } else if (!flags.quiet && isTTY) {
         process.stderr.write(`\n    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -227,14 +227,28 @@ export default defineCommand({
       // ── Handle failure ───────────────────────────────────
       if (result.status === "failed") {
         if (flags.json) console.log(JSON.stringify(result));
-        else if (!flags.quiet) steps.info(pc.red(`✗ ${result.error ?? "Job failed"}`));
+        else if (!flags.quiet) {
+          steps.info(pc.red(`✗ ${result.error ?? "Job failed"}`));
+          // Surface the ffmpeg stderr tail so failures are debuggable in-place.
+          if (result.errorDetail) {
+            for (const line of result.errorDetail.trimEnd().split("\n")) {
+              steps.info(pc.dim(line));
+            }
+          }
+        }
         process.exit(1);
       }
       if (result.status === "cancelled") process.exit(130);
 
       // ── Output modes ─────────────────────────────────────
       if (flags.json) { console.log(JSON.stringify(result)); process.exit(0); }
-      if (flags.urlOnly) { if (result.outputUrl) console.log(result.outputUrl); process.exit(0); }
+      if (flags.urlOnly) {
+        // Served multi-file jobs have no single outputUrl; fall back to the
+        // served entry URL (stream playlist) when present.
+        const url = result.outputUrl ?? result.output?.url ?? result.output?.baseUrl;
+        if (url) console.log(url);
+        process.exit(0);
+      }
 
       // ── 4. Download output ───────────────────────────────
       if (parsed.outputFile && result.outputUrl) {
@@ -247,6 +261,14 @@ export default defineCommand({
           process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(parsed.outputFile)}\n`);
           process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
         }
+      } else if (result.output && !flags.quiet && isTTY) {
+        // Served multi-file output: no single file to save. Show the served
+        // entry URL plus how many files sit under the prefix.
+        const servedUrl = result.output.url ?? result.output.baseUrl;
+        const fileLabel = result.output.fileCount === 1 ? "file" : "files";
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(servedUrl)}\n`);
+        process.stderr.write(`    ${pc.dim(`${result.output.fileCount} ${fileLabel}`)}\n`);
+        process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
       } else if (!flags.quiet && isTTY) {
         process.stderr.write(`\n    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
       }

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -245,42 +245,59 @@ export default defineCommand({
       // ── Output modes ─────────────────────────────────────
       if (flags.json) { console.log(JSON.stringify(result)); process.exit(0); }
       if (flags.urlOnly) {
-        // file/stream → playable url; set → prefix base url.
-        if (result.output) console.log(outputUrl(result.output));
+        // headline file url (single file or stream manifest); first file for a set.
+        const url = result.output ? outputUrl(result.output) : undefined;
+        if (url) console.log(url);
         process.exit(0);
       }
 
-      // ── 4. Download output ───────────────────────────────
+      // ── 4. Download / render output ──────────────────────
+      // Unified output shape: `file` is the headline (single file or stream
+      // manifest), `files` lists every produced file, `data` is the computed
+      // answer for data-only jobs. We render whichever applies.
       const out = result.output;
-      if (parsed.outputFile && out?.kind === "file") {
+      const file = out?.file ?? null;
+      const isStream = file?.type === "playlist";
+      const dashboardLine = `    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`;
+
+      if (parsed.outputFile && file && !isStream) {
+        // Headline single file + a local output path requested: download it.
         const outputPath = path.resolve(parsed.outputFile);
         await steps.step("Saving", async () => {
           return downloadOutput(client, job.id, outputPath);
         });
 
         if (!flags.quiet && isTTY) {
-          const dims = out.meta.width && out.meta.height ? ` ${pc.dim(`${out.meta.width}×${out.meta.height}`)}` : "";
+          const dims = file.meta?.width && file.meta?.height ? ` ${pc.dim(`${file.meta.width}×${file.meta.height}`)}` : "";
           process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(parsed.outputFile)}${dims}\n`);
-          process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
+          process.stderr.write(dashboardLine);
         }
-      } else if (out?.kind === "file" && !flags.quiet && isTTY) {
-        // Single output, no local file requested: print its download URL.
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(out.url)}\n`);
-        process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
-      } else if (out?.kind === "stream" && !flags.quiet && isTTY) {
-        // HLS/DASH stream: print the playable entry playlist + file count.
-        const fileLabel = out.fileCount === 1 ? "file" : "files";
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(out.url)}\n`);
-        process.stderr.write(`    ${pc.dim(`${out.manifest.toUpperCase()} · ${out.fileCount} ${fileLabel}`)}\n`);
-        process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
-      } else if (out?.kind === "set" && !flags.quiet && isTTY) {
-        // Unordered multi-file set: no entry url, print the prefix base + count.
-        const fileLabel = out.fileCount === 1 ? "file" : "files";
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(out.baseUrl)}\n`);
-        process.stderr.write(`    ${pc.dim(`${out.fileCount} ${fileLabel}`)}\n`);
-        process.stderr.write(`    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
+      } else if (isStream && file && out && !flags.quiet && isTTY) {
+        // HLS/DASH stream: print the playable manifest url + file count.
+        const count = out.files.length;
+        const fileLabel = count === 1 ? "file" : "files";
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(file.url)}\n`);
+        if (count > 0) process.stderr.write(`    ${pc.dim(`${count} ${fileLabel}`)}\n`);
+        process.stderr.write(dashboardLine);
+      } else if (file && !flags.quiet && isTTY) {
+        // Single output, no local file requested: print its download URL + dims.
+        const dims = file.meta?.width && file.meta?.height ? ` ${pc.dim(`${file.meta.width}×${file.meta.height}`)}` : "";
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(file.url)}${dims}\n`);
+        process.stderr.write(dashboardLine);
+      } else if (out && out.files.length > 0 && !flags.quiet && isTTY) {
+        // Unordered multi-file set (no headline file): list each produced file.
+        const fileLabel = out.files.length === 1 ? "file" : "files";
+        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(`${out.files.length} ${fileLabel}`)}\n`);
+        for (const f of out.files) {
+          process.stderr.write(`    ${pc.dim(f.path || f.url)}\n`);
+        }
+        process.stderr.write(dashboardLine);
+      } else if (out && out.data !== null && out.data !== undefined && !flags.quiet && isTTY) {
+        // Data-only job: print the structured result as pretty JSON.
+        process.stderr.write(`\n${JSON.stringify(out.data, null, 2)}\n`);
+        process.stderr.write(dashboardLine);
       } else if (!flags.quiet && isTTY) {
-        process.stderr.write(`\n    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`);
+        process.stderr.write(`\n${dashboardLine}`);
       }
 
       process.exit(0);

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -9,16 +9,45 @@ import { defineCommand } from "citty";
 import * as path from "node:path";
 import pc from "picocolors";
 import { createClient, isApiError } from "@rendobar/sdk";
-import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl } from "../lib/auth.js";
+import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, getDashboardBaseUrl } from "../lib/auth.js";
 import { parseFfmpegArgs } from "../lib/parse-ffmpeg-args.js";
 import { shellEscape } from "../lib/shell-escape.js";
 import { uploadLocalFiles } from "../lib/upload.js";
-import { StepRenderer, waitForJob, downloadOutput, outputUrl, type MachineContext } from "../lib/progress.js";
+import {
+  StepRenderer,
+  waitForJob,
+  downloadUrlToFile,
+  downloadFilesToDir,
+  outputUrl,
+  type MachineContext,
+} from "../lib/progress.js";
 
 function fmtMs(ms: number): string {
   if (ms < 100) return `${ms}ms`;
   if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`;
   return `${Math.round(ms / 1000)}s`;
+}
+
+/**
+ * Default local folder name for a multi-file/stream output. Prefer the basename
+ * (without extension) of the output token the user named, else a remote path.
+ */
+function defaultDirName(outputFile: string | null, fallbackPath: string | undefined): string {
+  const source = outputFile ?? fallbackPath ?? "output";
+  const base = path.basename(source);
+  const dot = base.lastIndexOf(".");
+  const stem = dot > 0 ? base.slice(0, dot) : base;
+  return stem.length > 0 ? stem : "output";
+}
+
+/**
+ * Find the locally-written manifest path among the downloaded files, matching by
+ * the remote manifest's basename (`.m3u8` / `.mpd`).
+ */
+function localManifestPath(written: string[], manifestRemotePath: string): string | undefined {
+  const name = path.basename(manifestRemotePath);
+  if (name.length === 0) return undefined;
+  return written.find((p) => path.basename(p) === name);
 }
 
 // ── Flags ──────────────────────────────────────────────────────
@@ -28,19 +57,38 @@ interface GlobalFlags {
   urlOnly: boolean;
   quiet: boolean;
   noWait: boolean;
+  noDownload: boolean;
+  output: string | null;
+  outputDir: string | null;
   timeout: number;
 }
 
 function extractGlobalFlags(): GlobalFlags {
   const argv = process.argv;
-  const flags: GlobalFlags = { json: false, urlOnly: false, quiet: false, noWait: false, timeout: 120 };
+  const flags: GlobalFlags = {
+    json: false,
+    urlOnly: false,
+    quiet: false,
+    noWait: false,
+    noDownload: false,
+    output: null,
+    outputDir: null,
+    timeout: 120,
+  };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     if (arg === "--json") flags.json = true;
     else if (arg === "--url-only") flags.urlOnly = true;
     else if (arg === "--quiet") flags.quiet = true;
     else if (arg === "--no-wait") flags.noWait = true;
-    else if (arg === "--timeout" && i + 1 < argv.length) {
+    else if (arg === "--no-download") flags.noDownload = true;
+    else if (arg === "--output" && i + 1 < argv.length) {
+      flags.output = argv[i + 1]!; // Guarded by i + 1 < argv.length
+      i++;
+    } else if (arg === "--output-dir" && i + 1 < argv.length) {
+      flags.outputDir = argv[i + 1]!; // Guarded by i + 1 < argv.length
+      i++;
+    } else if (arg === "--timeout" && i + 1 < argv.length) {
       // Guarded by i + 1 < argv.length above
       const val = parseInt(argv[i + 1]!, 10);
       if (!Number.isNaN(val) && val > 0) flags.timeout = Math.min(val, 900);
@@ -54,8 +102,8 @@ function extractFfmpegArgs(): string[] {
   const argv = process.argv;
   const ffmpegIdx = argv.indexOf("ffmpeg");
   if (ffmpegIdx === -1) return [];
-  const globalFlags = new Set(["--json", "--url-only", "--quiet", "--no-wait"]);
-  const globalFlagsWithValue = new Set(["--timeout"]);
+  const globalFlags = new Set(["--json", "--url-only", "--quiet", "--no-wait", "--no-download"]);
+  const globalFlagsWithValue = new Set(["--timeout", "--output", "--output-dir"]);
   const result: string[] = [];
   for (let i = ffmpegIdx + 1; i < argv.length; i++) {
     const arg = argv[i]!;
@@ -78,12 +126,16 @@ ${pc.bold("Examples:")}
   rb ffmpeg -i https://example.com/video.mp4 -ss 10 -t 30 clip.mp4
 
 ${pc.bold("Flags:")}
-  --json       Output full JSON result to stdout
-  --url-only   Output only the result URL to stdout
-  --quiet      No output, exit code only
-  --no-wait    Submit and exit immediately (prints job ID)
-  --timeout N  Max execution time in seconds (default: 120, max: 900)
+  --output <path>     Write the output to this local path
+  --output-dir <dir>  Write a multi-file/stream output into this local folder
+  --no-download       Submit and report, but don't download
+  --url-only          Print the result URL(s), download nothing
+  --json              Output full JSON result to stdout
+  --quiet             No output, exit code only
+  --no-wait           Submit and exit immediately (prints job ID)
+  --timeout N         Max execution time in seconds (default: 120, max: 900)
 
+${pc.dim("Outputs download to your folder by default — like running ffmpeg locally.")}
 ${pc.dim("Local files are auto-uploaded before job submission.")}
 ${pc.dim("All FFmpeg flags are passed through to the cloud executor.")}
 `);
@@ -251,51 +303,92 @@ export default defineCommand({
         process.exit(0);
       }
 
-      // ── 4. Download / render output ──────────────────────
+      // ── 4. Download outputs locally (like a local tool) ──
       // Unified output shape: `file` is the headline (single file or stream
       // manifest), `files` lists every produced file, `data` is the computed
-      // answer for data-only jobs. We render whichever applies.
+      // answer for data-only jobs. Default behavior downloads the produced
+      // file(s) into the user's folder so `out.mp4` simply appears — exactly
+      // like running ffmpeg locally. Every fetch uses the signed url already in
+      // the response; no host is ever reconstructed.
       const out = result.output;
       const file = out?.file ?? null;
       const isStream = file?.type === "playlist";
-      const dashboardLine = `    ${pc.dim(`https://app.rendobar.com/jobs/${job.id}`)}\n`;
+      const dashboardLine = `    ${pc.dim(`${getDashboardBaseUrl()}/jobs/${job.id}`)}\n`;
+      const hasData = Boolean(out && out.data !== null && out.data !== undefined);
 
-      if (parsed.outputFile && file && !isStream) {
-        // Headline single file + a local output path requested: download it.
-        const outputPath = path.resolve(parsed.outputFile);
-        await steps.step("Saving", async () => {
-          return downloadOutput(client, job.id, outputPath);
-        });
+      // --no-download: submit + report only, never write to disk.
+      if (flags.noDownload) {
+        if (!flags.quiet && isTTY) {
+          if (file) {
+            const dims = file.meta?.width && file.meta?.height ? ` ${pc.dim(`${file.meta.width}×${file.meta.height}`)}` : "";
+            process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(file.url)}${dims}\n`);
+          } else if (out && out.files.length > 0) {
+            const label = out.files.length === 1 ? "file" : "files";
+            process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(`${out.files.length} ${label}`)}\n`);
+          } else if (hasData && out) {
+            process.stderr.write(`\n${JSON.stringify(out.data, null, 2)}\n`);
+          }
+          process.stderr.write(dashboardLine);
+        }
+        process.exit(0);
+      }
+
+      if (!out) {
+        // No output object (unexpected) — just point at the dashboard.
+        if (!flags.quiet && isTTY) process.stderr.write(`\n${dashboardLine}`);
+        process.exit(0);
+      }
+
+      if (file && !isStream && out.files.length <= 1) {
+        // ── single file ── download to the user-named output path.
+        const targetName = flags.output ?? parsed.outputFile ?? path.basename(file.path || "output");
+        const outputPath = path.resolve(targetName);
+        await steps.step("Saving", async () => downloadUrlToFile(file.url, outputPath, controller.signal));
 
         if (!flags.quiet && isTTY) {
           const dims = file.meta?.width && file.meta?.height ? ` ${pc.dim(`${file.meta.width}×${file.meta.height}`)}` : "";
-          process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(parsed.outputFile)}${dims}\n`);
+          process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(path.relative(process.cwd(), outputPath) || targetName)}${dims}\n`);
           process.stderr.write(dashboardLine);
         }
-      } else if (isStream && file && out && !flags.quiet && isTTY) {
-        // HLS/DASH stream: print the playable manifest url + file count.
-        const count = out.files.length;
-        const fileLabel = count === 1 ? "file" : "files";
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(file.url)}\n`);
-        if (count > 0) process.stderr.write(`    ${pc.dim(`${count} ${fileLabel}`)}\n`);
-        process.stderr.write(dashboardLine);
-      } else if (file && !flags.quiet && isTTY) {
-        // Single output, no local file requested: print its download URL + dims.
-        const dims = file.meta?.width && file.meta?.height ? ` ${pc.dim(`${file.meta.width}×${file.meta.height}`)}` : "";
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(file.url)}${dims}\n`);
-        process.stderr.write(dashboardLine);
-      } else if (out && out.files.length > 0 && !flags.quiet && isTTY) {
-        // Unordered multi-file set (no headline file): list each produced file.
-        const fileLabel = out.files.length === 1 ? "file" : "files";
-        process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(`${out.files.length} ${fileLabel}`)}\n`);
-        for (const f of out.files) {
-          process.stderr.write(`    ${pc.dim(f.path || f.url)}\n`);
+      } else if (isStream && file) {
+        // ── stream ── download the manifest + every segment into a folder so
+        // it plays locally; print the local manifest path.
+        const dir = path.resolve(flags.outputDir ?? flags.output ?? defaultDirName(parsed.outputFile, file.path));
+        const written = await steps.step("Saving", async () => downloadFilesToDir(out.files, dir, controller.signal));
+
+        if (!flags.quiet && isTTY) {
+          const manifest = localManifestPath(written, file.path) ?? dir;
+          const label = written.length === 1 ? "file" : "files";
+          process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(path.relative(process.cwd(), manifest) || manifest)}\n`);
+          process.stderr.write(`    ${pc.dim(`${written.length} ${label}`)}\n`);
+          process.stderr.write(dashboardLine);
         }
-        process.stderr.write(dashboardLine);
-      } else if (out && out.data !== null && out.data !== undefined && !flags.quiet && isTTY) {
-        // Data-only job: print the structured result as pretty JSON.
-        process.stderr.write(`\n${JSON.stringify(out.data, null, 2)}\n`);
-        process.stderr.write(dashboardLine);
+      } else if (out.files.length > 0) {
+        // ── set ── download all files into a folder, preserving each path.
+        const dir = path.resolve(flags.outputDir ?? flags.output ?? defaultDirName(parsed.outputFile, out.files[0]?.path));
+        const written = await steps.step("Saving", async () => downloadFilesToDir(out.files, dir, controller.signal));
+
+        if (!flags.quiet && isTTY) {
+          const label = written.length === 1 ? "file" : "files";
+          process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(path.relative(process.cwd(), dir) || dir)}${path.sep}\n`);
+          process.stderr.write(`    ${pc.dim(`${written.length} ${label}`)}\n`);
+          process.stderr.write(dashboardLine);
+        }
+      } else if (hasData) {
+        // ── data job ── print structured data as pretty JSON; optionally write.
+        const pretty = JSON.stringify(out.data, null, 2);
+        if (flags.output) {
+          const outputPath = path.resolve(flags.output);
+          await steps.step("Saving", async () => { await Bun.write(outputPath, pretty); });
+          if (!flags.quiet && isTTY) {
+            process.stderr.write(`\n  ${pc.green("→")} ${pc.bold(path.relative(process.cwd(), outputPath) || flags.output)}\n`);
+            process.stderr.write(dashboardLine);
+          }
+        } else {
+          // Structured answer goes to stdout so it can be piped (e.g. to jq).
+          console.log(pretty);
+          if (!flags.quiet && isTTY) process.stderr.write(dashboardLine);
+        }
       } else if (!flags.quiet && isTTY) {
         process.stderr.write(`\n${dashboardLine}`);
       }
@@ -307,7 +400,7 @@ export default defineCommand({
       if (isApiError(err)) {
         if (err.code === "INSUFFICIENT_CREDITS") {
           process.stderr.write(pc.red(`  ✗ Insufficient credits. ${err.message}\n`));
-          process.stderr.write(`    Top up: ${pc.cyan("https://app.rendobar.com/billing")}\n`);
+          process.stderr.write(`    Top up: ${pc.cyan(`${getDashboardBaseUrl()}/billing`)}\n`);
           process.exit(2);
         }
         if (flags.json) console.log(JSON.stringify({ error: { code: err.code, message: err.message } }));

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,6 +8,10 @@ export function getApiBaseUrl(): string {
   return process.env.RENDOBAR_API_URL ?? "https://api.rendobar.com";
 }
 
+export function getDashboardBaseUrl(): string {
+  return process.env.RENDOBAR_APP_URL ?? "https://app.rendobar.com";
+}
+
 // ── Types ────────────────────────────────────────────────────
 
 export type AuthCredential =

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -14,7 +14,7 @@ import type { RendobarClient } from "@rendobar/sdk";
 
 export interface ProgressResult {
   status: string;
-  /** Discriminated job output, present only when status === "complete". */
+  /** Unified job output, present only when status === "complete". */
   output?: JobOutput;
   /** Structured failure, present only when status === "failed". */
   error?: JobError;
@@ -37,43 +37,36 @@ export interface MachineContext {
 }
 
 /**
- * Discriminated job output (mirrors the API `Output` union, keyed on `kind`).
+ * Unified job output (mirrors the API `Output` shape — one shape for every job
+ * type). The published `@rendobar/sdk` may still export the old discriminated
+ * union, so the CLI narrows the runtime job object defensively against this new
+ * shape. Only the fields the CLI renders are modelled.
  *
- * The published `@rendobar/sdk` does not export this union yet (it ships in a
- * later SDK release), so the CLI narrows the runtime job object defensively
- * against the same shape. Only the fields the CLI renders are modelled.
- *
- *  - file   : single download URL + probe metadata.
- *  - stream : HLS/DASH playlist (entry url + manifest hint) over a served prefix.
- *  - set    : unordered multi-file collection over a served prefix (no entry url).
+ *  - data  : computed answer (job-specific JSON), or null for file-only jobs.
+ *  - file  : the headline file — single output OR stream manifest — or null for
+ *            data-only jobs and unordered sets.
+ *  - files : every produced file ([] for data-only jobs).
  */
-export type JobOutput =
-  | {
-      kind: "file";
-      url: string;
-      poster: string | null;
-      meta: {
-        format?: string;
-        width?: number;
-        height?: number;
-        durationMs?: number;
-        sizeBytes?: number;
-      };
-    }
-  | {
-      kind: "stream";
-      url: string;
-      manifest: "hls" | "dash";
-      baseUrl: string;
-      fileCount: number;
-      manifestUrl: string;
-    }
-  | {
-      kind: "set";
-      baseUrl: string;
-      fileCount: number;
-      manifestUrl: string;
-    };
+export interface JobOutput {
+  data: unknown;
+  file: JobFile | null;
+  files: JobFile[];
+  expiresAt: number | null;
+}
+
+/** A single produced file (mirrors the API `File` shape). */
+export interface JobFile {
+  url: string;
+  path: string;
+  type: "video" | "image" | "audio" | "captions" | "playlist" | "data" | "other";
+  size: number;
+  meta?: {
+    format?: string;
+    width?: number;
+    height?: number;
+    durationMs?: number;
+  };
+}
 
 /** Structured failure (mirrors the API `error` object). */
 export interface JobError {
@@ -85,23 +78,14 @@ export interface JobError {
 }
 
 /**
- * The single playable/download URL for an output: the download URL for a file,
- * the entry playlist for a stream, the prefix base URL for a set (which has no
- * entry url). Mirrors the SDK's `outputUrl(job)` helper for sets-vs-not, but
- * always returns a string so `--url-only` has something to print.
+ * The single playable/download URL for an output: the headline `file` url
+ * (single file or stream manifest) when present, otherwise the first of `files`
+ * for an unordered set. Returns undefined for data-only outputs (no file) so
+ * `--url-only` prints nothing.
  */
-export function outputUrl(output: JobOutput): string {
-  switch (output.kind) {
-    case "file":
-    case "stream":
-      return output.url;
-    case "set":
-      return output.baseUrl;
-    default: {
-      const _exhaustive: never = output;
-      return _exhaustive;
-    }
-  }
+export function outputUrl(output: JobOutput): string | undefined {
+  if (output.file) return output.file.url;
+  return output.files[0]?.url;
 }
 
 // ── ANSI ───────────────────────────────────────────────────────
@@ -291,71 +275,61 @@ function optNumber(v: unknown): number | undefined {
   return typeof v === "number" ? v : undefined;
 }
 
+const FILE_TYPES = new Set(["video", "image", "audio", "captions", "playlist", "data", "other"]);
+
+/**
+ * Narrow an unknown value into a `JobFile`. Returns undefined when the shape is
+ * unexpected (missing url, etc).
+ */
+function parseFile(raw: unknown): JobFile | undefined {
+  const f = asRecord(raw);
+  if (!f) return undefined;
+  if (typeof f.url !== "string") return undefined;
+  const type = typeof f.type === "string" && FILE_TYPES.has(f.type)
+    ? (f.type as JobFile["type"])
+    : "other";
+  const meta = asRecord(f.meta);
+  return {
+    url: f.url,
+    path: typeof f.path === "string" ? f.path : "",
+    type,
+    size: optNumber(f.size) ?? 0,
+    meta: meta
+      ? {
+          format: optString(meta.format),
+          width: optNumber(meta.width),
+          height: optNumber(meta.height),
+          durationMs: optNumber(meta.durationMs),
+        }
+      : undefined,
+  };
+}
+
 /**
  * Narrow an unknown `output` field (from the runtime job object) into the
- * discriminated `JobOutput` the CLI renders. Returns undefined when there is no
- * output (job not complete) or the shape is unexpected. Read off
- * `Record<string, unknown>` because the published SDK type does not export this
- * union yet.
+ * unified `JobOutput` the CLI renders. Returns undefined when there is no output
+ * (job not complete) or the shape is unexpected. Read off
+ * `Record<string, unknown>` because the published SDK type may still carry the
+ * old discriminated union.
  */
 function parseOutput(raw: unknown): JobOutput | undefined {
   const o = asRecord(raw);
   if (!o) return undefined;
 
-  if (o.kind === "file") {
-    if (typeof o.url !== "string") return undefined;
-    const meta = asRecord(o.meta) ?? {};
-    return {
-      kind: "file",
-      url: o.url,
-      poster: typeof o.poster === "string" ? o.poster : null,
-      meta: {
-        format: optString(meta.format),
-        width: optNumber(meta.width),
-        height: optNumber(meta.height),
-        durationMs: optNumber(meta.durationMs),
-        sizeBytes: optNumber(meta.sizeBytes),
-      },
-    };
-  }
+  // The unified shape always carries a `files` array. Require it to avoid
+  // mis-reading an old-shaped or malformed object as an empty output.
+  if (!Array.isArray(o.files)) return undefined;
 
-  if (o.kind === "stream") {
-    if (
-      typeof o.url !== "string" ||
-      (o.manifest !== "hls" && o.manifest !== "dash") ||
-      typeof o.baseUrl !== "string" ||
-      typeof o.fileCount !== "number" ||
-      typeof o.manifestUrl !== "string"
-    ) {
-      return undefined;
-    }
-    return {
-      kind: "stream",
-      url: o.url,
-      manifest: o.manifest,
-      baseUrl: o.baseUrl,
-      fileCount: o.fileCount,
-      manifestUrl: o.manifestUrl,
-    };
-  }
+  const files = o.files
+    .map(parseFile)
+    .filter((f): f is JobFile => f !== undefined);
 
-  if (o.kind === "set") {
-    if (
-      typeof o.baseUrl !== "string" ||
-      typeof o.fileCount !== "number" ||
-      typeof o.manifestUrl !== "string"
-    ) {
-      return undefined;
-    }
-    return {
-      kind: "set",
-      baseUrl: o.baseUrl,
-      fileCount: o.fileCount,
-      manifestUrl: o.manifestUrl,
-    };
-  }
-
-  return undefined;
+  return {
+    data: "data" in o ? o.data : null,
+    file: o.file === null || o.file === undefined ? null : (parseFile(o.file) ?? null),
+    files,
+    expiresAt: optNumber(o.expiresAt) ?? null,
+  };
 }
 
 /**

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -56,6 +56,14 @@ export interface ServedOutput {
   fileCount: number;
 }
 
+/**
+ * The single URL to surface for a served output: the stream's entry playlist
+ * when present, otherwise the prefix base URL (sets have no entry url).
+ */
+export function servedEntryUrl(output: ServedOutput): string {
+  return output.url ?? output.baseUrl;
+}
+
 // ── ANSI ───────────────────────────────────────────────────────
 
 const ESC = "\x1b[";

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -15,7 +15,11 @@ import type { RendobarClient } from "@rendobar/sdk";
 export interface ProgressResult {
   status: string;
   outputUrl?: string;
+  /** Served multi-file output (HLS/DASH, image sequence, resolution ladder). */
+  output?: ServedOutput;
   error?: string;
+  /** Last ~2 KB of ffmpeg stderr when the job failed at execution. */
+  errorDetail?: string;
   /** Total: Created → Completed */
   duration: number;
   /** Created → Dispatched (API processing + queue dispatch) */
@@ -32,6 +36,24 @@ export interface MachineContext {
   cpu: number;
   memory: number;
   region?: string;
+}
+
+/**
+ * Served multi-file output. A single ffmpeg job can now emit a token-served
+ * prefix (HLS/DASH playlist, image sequence, resolution ladder) instead of one
+ * file. The published SDK type may not include this field yet (separate SDK
+ * release), so we read it defensively from the runtime job object. Only the
+ * fields the CLI renders are modelled here.
+ */
+export interface ServedOutput {
+  /** stream = HLS/DASH playlist; set = unordered multi-file collection. */
+  type: "stream" | "set";
+  /** Primary URL: the entry playlist for a stream; absent for a set. */
+  url?: string;
+  /** Token-in-path serving base URL for the prefix (trailing slash). */
+  baseUrl: string;
+  /** Total number of files under the served prefix. */
+  fileCount: number;
 }
 
 // ── ANSI ───────────────────────────────────────────────────────
@@ -182,7 +204,7 @@ interface WsResult {
   machine?: MachineContext;
 }
 
-function buildResult(status: string, machine: MachineContext | undefined, job: Record<string, unknown>): ProgressResult {
+export function buildResult(status: string, machine: MachineContext | undefined, job: Record<string, unknown>): ProgressResult {
   const createdAt = typeof job.createdAt === "number" ? job.createdAt : 0;
   const dispatchedAt = typeof job.dispatchedAt === "number" ? job.dispatchedAt : 0;
   const startedAt = typeof job.startedAt === "number" ? job.startedAt : 0;
@@ -200,12 +222,33 @@ function buildResult(status: string, machine: MachineContext | undefined, job: R
   return {
     status,
     outputUrl: typeof job.outputUrl === "string" ? job.outputUrl : undefined,
+    output: parseServedOutput(job.output),
     error: typeof job.errorMessage === "string" ? job.errorMessage : undefined,
+    errorDetail: typeof job.errorDetail === "string" ? job.errorDetail : undefined,
     duration: totalMs,
     dispatchMs,
     queueMs,
     execMs,
     machine,
+  };
+}
+
+/**
+ * Narrow an unknown `output` field (from the runtime job object) into the
+ * served-output summary the CLI renders. Returns undefined for single-output
+ * jobs (no `output` object) or any unexpected shape. The published SDK type may
+ * not carry this field yet, so this is read off `Record<string, unknown>`.
+ */
+function parseServedOutput(raw: unknown): ServedOutput | undefined {
+  if (!raw || typeof raw !== "object") return undefined;
+  const o = raw as Record<string, unknown>;
+  if (o.type !== "stream" && o.type !== "set") return undefined;
+  if (typeof o.baseUrl !== "string" || typeof o.fileCount !== "number") return undefined;
+  return {
+    type: o.type,
+    url: typeof o.url === "string" ? o.url : undefined,
+    baseUrl: o.baseUrl,
+    fileCount: o.fileCount,
   };
 }
 

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -14,12 +14,10 @@ import type { RendobarClient } from "@rendobar/sdk";
 
 export interface ProgressResult {
   status: string;
-  outputUrl?: string;
-  /** Served multi-file output (HLS/DASH, image sequence, resolution ladder). */
-  output?: ServedOutput;
-  error?: string;
-  /** Last ~2 KB of ffmpeg stderr when the job failed at execution. */
-  errorDetail?: string;
+  /** Discriminated job output, present only when status === "complete". */
+  output?: JobOutput;
+  /** Structured failure, present only when status === "failed". */
+  error?: JobError;
   /** Total: Created → Completed */
   duration: number;
   /** Created → Dispatched (API processing + queue dispatch) */
@@ -39,29 +37,71 @@ export interface MachineContext {
 }
 
 /**
- * Served multi-file output. A single ffmpeg job can now emit a token-served
- * prefix (HLS/DASH playlist, image sequence, resolution ladder) instead of one
- * file. The published SDK type may not include this field yet (separate SDK
- * release), so we read it defensively from the runtime job object. Only the
- * fields the CLI renders are modelled here.
+ * Discriminated job output (mirrors the API `Output` union, keyed on `kind`).
+ *
+ * The published `@rendobar/sdk` does not export this union yet (it ships in a
+ * later SDK release), so the CLI narrows the runtime job object defensively
+ * against the same shape. Only the fields the CLI renders are modelled.
+ *
+ *  - file   : single download URL + probe metadata.
+ *  - stream : HLS/DASH playlist (entry url + manifest hint) over a served prefix.
+ *  - set    : unordered multi-file collection over a served prefix (no entry url).
  */
-export interface ServedOutput {
-  /** stream = HLS/DASH playlist; set = unordered multi-file collection. */
-  type: "stream" | "set";
-  /** Primary URL: the entry playlist for a stream; absent for a set. */
-  url?: string;
-  /** Token-in-path serving base URL for the prefix (trailing slash). */
-  baseUrl: string;
-  /** Total number of files under the served prefix. */
-  fileCount: number;
+export type JobOutput =
+  | {
+      kind: "file";
+      url: string;
+      poster: string | null;
+      meta: {
+        format?: string;
+        width?: number;
+        height?: number;
+        durationMs?: number;
+        sizeBytes?: number;
+      };
+    }
+  | {
+      kind: "stream";
+      url: string;
+      manifest: "hls" | "dash";
+      baseUrl: string;
+      fileCount: number;
+      manifestUrl: string;
+    }
+  | {
+      kind: "set";
+      baseUrl: string;
+      fileCount: number;
+      manifestUrl: string;
+    };
+
+/** Structured failure (mirrors the API `error` object). */
+export interface JobError {
+  code: string;
+  message: string;
+  /** Real provider stderr tail (e.g. ffmpeg), or null. */
+  detail: string | null;
+  retryable: boolean;
 }
 
 /**
- * The single URL to surface for a served output: the stream's entry playlist
- * when present, otherwise the prefix base URL (sets have no entry url).
+ * The single playable/download URL for an output: the download URL for a file,
+ * the entry playlist for a stream, the prefix base URL for a set (which has no
+ * entry url). Mirrors the SDK's `outputUrl(job)` helper for sets-vs-not, but
+ * always returns a string so `--url-only` has something to print.
  */
-export function servedEntryUrl(output: ServedOutput): string {
-  return output.url ?? output.baseUrl;
+export function outputUrl(output: JobOutput): string {
+  switch (output.kind) {
+    case "file":
+    case "stream":
+      return output.url;
+    case "set":
+      return output.baseUrl;
+    default: {
+      const _exhaustive: never = output;
+      return _exhaustive;
+    }
+  }
 }
 
 // ── ANSI ───────────────────────────────────────────────────────
@@ -229,10 +269,8 @@ export function buildResult(status: string, machine: MachineContext | undefined,
 
   return {
     status,
-    outputUrl: typeof job.outputUrl === "string" ? job.outputUrl : undefined,
-    output: parseServedOutput(job.output),
-    error: typeof job.errorMessage === "string" ? job.errorMessage : undefined,
-    errorDetail: typeof job.errorDetail === "string" ? job.errorDetail : undefined,
+    output: parseOutput(job.output),
+    error: parseError(job.error),
     duration: totalMs,
     dispatchMs,
     queueMs,
@@ -241,22 +279,98 @@ export function buildResult(status: string, machine: MachineContext | undefined,
   };
 }
 
+function asRecord(raw: unknown): Record<string, unknown> | undefined {
+  return raw && typeof raw === "object" ? (raw as Record<string, unknown>) : undefined;
+}
+
+function optString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+function optNumber(v: unknown): number | undefined {
+  return typeof v === "number" ? v : undefined;
+}
+
 /**
  * Narrow an unknown `output` field (from the runtime job object) into the
- * served-output summary the CLI renders. Returns undefined for single-output
- * jobs (no `output` object) or any unexpected shape. The published SDK type may
- * not carry this field yet, so this is read off `Record<string, unknown>`.
+ * discriminated `JobOutput` the CLI renders. Returns undefined when there is no
+ * output (job not complete) or the shape is unexpected. Read off
+ * `Record<string, unknown>` because the published SDK type does not export this
+ * union yet.
  */
-function parseServedOutput(raw: unknown): ServedOutput | undefined {
-  if (!raw || typeof raw !== "object") return undefined;
-  const o = raw as Record<string, unknown>;
-  if (o.type !== "stream" && o.type !== "set") return undefined;
-  if (typeof o.baseUrl !== "string" || typeof o.fileCount !== "number") return undefined;
+function parseOutput(raw: unknown): JobOutput | undefined {
+  const o = asRecord(raw);
+  if (!o) return undefined;
+
+  if (o.kind === "file") {
+    if (typeof o.url !== "string") return undefined;
+    const meta = asRecord(o.meta) ?? {};
+    return {
+      kind: "file",
+      url: o.url,
+      poster: typeof o.poster === "string" ? o.poster : null,
+      meta: {
+        format: optString(meta.format),
+        width: optNumber(meta.width),
+        height: optNumber(meta.height),
+        durationMs: optNumber(meta.durationMs),
+        sizeBytes: optNumber(meta.sizeBytes),
+      },
+    };
+  }
+
+  if (o.kind === "stream") {
+    if (
+      typeof o.url !== "string" ||
+      (o.manifest !== "hls" && o.manifest !== "dash") ||
+      typeof o.baseUrl !== "string" ||
+      typeof o.fileCount !== "number" ||
+      typeof o.manifestUrl !== "string"
+    ) {
+      return undefined;
+    }
+    return {
+      kind: "stream",
+      url: o.url,
+      manifest: o.manifest,
+      baseUrl: o.baseUrl,
+      fileCount: o.fileCount,
+      manifestUrl: o.manifestUrl,
+    };
+  }
+
+  if (o.kind === "set") {
+    if (
+      typeof o.baseUrl !== "string" ||
+      typeof o.fileCount !== "number" ||
+      typeof o.manifestUrl !== "string"
+    ) {
+      return undefined;
+    }
+    return {
+      kind: "set",
+      baseUrl: o.baseUrl,
+      fileCount: o.fileCount,
+      manifestUrl: o.manifestUrl,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Narrow an unknown `error` field into the structured `JobError` the CLI
+ * renders. Returns undefined when the shape is unexpected (e.g. no error).
+ */
+function parseError(raw: unknown): JobError | undefined {
+  const o = asRecord(raw);
+  if (!o) return undefined;
+  if (typeof o.code !== "string" || typeof o.message !== "string") return undefined;
   return {
-    type: o.type,
-    url: typeof o.url === "string" ? o.url : undefined,
-    baseUrl: o.baseUrl,
-    fileCount: o.fileCount,
+    code: o.code,
+    message: o.message,
+    detail: typeof o.detail === "string" ? o.detail : null,
+    retryable: o.retryable === true,
   };
 }
 

--- a/src/lib/progress.ts
+++ b/src/lib/progress.ts
@@ -7,6 +7,8 @@
  * waitForJob: WebSocket → polls for terminal status, captures machine
  * context from job.context events and passes to onContext callback.
  */
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
 import pc from "picocolors";
 import type { RendobarClient } from "@rendobar/sdk";
 
@@ -443,12 +445,11 @@ function waitViaWebSocket(
 
 // ── Download ───────────────────────────────────────────────────
 
-export async function downloadOutput(
-  client: RendobarClient,
-  jobId: string,
-  outputPath: string,
-): Promise<void> {
-  const response = await client.jobs.download(jobId);
+/**
+ * Stream a fetch `Response` body to a local path. Large bodies stream in 1 MiB
+ * chunks (bounded memory); small ones write in one shot.
+ */
+async function streamToFile(response: Response, outputPath: string): Promise<void> {
   const totalBytes = Number(response.headers.get("content-length") || 0);
 
   if (totalBytes > 1_000_000 && response.body) {
@@ -465,5 +466,73 @@ export async function downloadOutput(
     }
   } else {
     await Bun.write(outputPath, response);
+  }
+}
+
+/**
+ * Download the job's headline output via the SDK `/download` endpoint to a local
+ * path. Kept for the single-file case where no per-file url is needed.
+ */
+export async function downloadOutput(
+  client: RendobarClient,
+  jobId: string,
+  outputPath: string,
+): Promise<void> {
+  const response = await client.jobs.download(jobId);
+  await streamToFile(response, outputPath);
+}
+
+/**
+ * Download a single ready-to-fetch (signed) URL from the job response to a local
+ * path. Uses the url verbatim — never reconstructs a host.
+ */
+export async function downloadUrlToFile(
+  url: string,
+  outputPath: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const response = await fetch(url, { signal });
+  if (!response.ok) {
+    throw new Error(`Download failed (${response.status}) for ${url}`);
+  }
+  await streamToFile(response, outputPath);
+}
+
+/**
+ * Download every file of a set/stream output into a local directory, preserving
+ * each file's relative `path` (so an HLS manifest + its segments land alongside
+ * each other and play locally). Returns the local paths written.
+ *
+ * Each file is fetched from its own signed `url` in the response — no host is
+ * ever hardcoded.
+ */
+export async function downloadFilesToDir(
+  files: JobFile[],
+  dir: string,
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const written: string[] = [];
+  for (const file of files) {
+    // Fall back to the url's basename if the file carries no relative path.
+    const rel = file.path && file.path.trim().length > 0
+      ? file.path
+      : basenameFromUrl(file.url);
+    // Strip any leading slashes / drive-absolute prefix so join stays under dir.
+    const safeRel = rel.replace(/^([a-zA-Z]:)?[\\/]+/, "");
+    const target = path.join(dir, safeRel);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await downloadUrlToFile(file.url, target, signal);
+    written.push(target);
+  }
+  return written;
+}
+
+function basenameFromUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop();
+    return last && last.length > 0 ? decodeURIComponent(last) : "output";
+  } catch {
+    return "output";
   }
 }


### PR DESCRIPTION
## What

Surface the new ffmpeg output/error contract in `rb ffmpeg`:

- **Served multi-file output** (`output: { type: "stream" | "set", url?, baseUrl, fileCount, ... }`). Multi-file ffmpeg jobs (HLS/DASH playlists, image sequences, resolution ladders) carry no single `outputUrl` (the API sets `outputUrl: null` and puts everything under `output`). Before this change those jobs printed only the dashboard link and looked like they produced nothing. Now the success line shows the served entry URL plus the file count, `--url-only` falls back to the served `url` (or `baseUrl`), and the served object is included in `--json`.
- **`errorDetail`** (the ffmpeg stderr tail) is now printed under the error message on failed jobs, so failures are debuggable in place instead of forcing a trip to the dashboard.

## Why

The monorepo + SDK shipped a new job-response contract: multi-file outputs live in an `output` object and failed jobs include `errorDetail`. The CLI only read `outputUrl` / `errorMessage`, so served jobs showed no output and failures hid the real ffmpeg error.

## Notes

- The published `@rendobar/sdk@1.0.0` type does not yet include `output` / `errorDetail` (that's a separate SDK release). `buildResult` already takes the job as `Record<string, unknown>`, so these fields are read defensively and narrowed with a small guard — no SDK bump required.
- Single-output jobs are unchanged: `outputUrl` download path is untouched.

## Test plan

- `pnpm typecheck` — clean
- `pnpm test` — 111 pass (6 new: stream/set/single output, malformed-output rejection, errorDetail capture)
- `pnpm build` — compiles `rb.exe`