### PR TITLE
chore: auto-update internal @rendobar deps on publish

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,14 @@
     {
       "matchPackageNames": ["bun", "oven-sh/setup-bun"],
       "groupName": "bun"
+    },
+    {
+      "matchPackageNames": ["@rendobar/**"],
+      "matchUpdateTypes": ["patch", "minor"],
+      "schedule": ["at any time"],
+      "automerge": true,
+      "platformAutomerge": true,
+      "groupName": "rendobar internal deps"
     }
   ],
   "dependencyDashboard": true,


### PR DESCRIPTION
Renovate already automerges minor/patch bumps, but only within the weekly window (`before 6am on Monday`). That delays first-party `@rendobar/*` updates (most importantly `@rendobar/sdk`) by up to a week after an npm publish.

This adds one packageRule, scoped to `@rendobar/**`, that overrides the global schedule with `at any time` and automerges patch/minor. Result: when a new SDK version publishes, the bump PR opens and self-merges within minutes instead of waiting for Monday. Major `@rendobar/*` bumps still fall through to the existing major rule (no automerge, labelled for review).

No effect on third-party deps — they stay on the weekly batch.
