### PR TITLE
feat: attribute CLI traffic as client=cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",
-    "@rendobar/sdk": "^3.1.0",
+    "@rendobar/sdk": "^3.3.0",
     "citty": "^0.2.0",
     "picocolors": "^1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: ^1.2.0
         version: 1.6.0
       '@rendobar/sdk':
-        specifier: ^3.1.0
+        specifier: ^3.3.0
         version: 3.3.0
       citty:
         specifier: ^0.2.0
@@ -268,7 +268,6 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   global-directory@5.0.0:
@@ -380,8 +379,8 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
-  partysocket@1.3.0:
-    resolution: {integrity: sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA==}
+  partysocket@1.1.19:
+    resolution: {integrity: sha512-hPwsXSdUc8PKNCinET6TD3JQOxzQ2JaP0bUZQXBVl6UM8UuLn1odgf1LcJXHy4UHSQwWL/RU3AnyhEsGM+W+sg==}
     peerDependencies:
       react: '>=17'
     peerDependenciesMeta:
@@ -587,7 +586,7 @@ snapshots:
 
   '@rendobar/sdk@3.3.0':
     dependencies:
-      partysocket: 1.3.0
+      partysocket: 1.1.19
     transitivePeerDependencies:
       - react
 
@@ -799,7 +798,7 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
-  partysocket@1.3.0:
+  partysocket@1.1.19:
     dependencies:
       event-target-polyfill: 0.0.4
 

--- a/src/commands/ffmpeg.ts
+++ b/src/commands/ffmpeg.ts
@@ -8,7 +8,8 @@
 import { defineCommand } from "citty";
 import * as path from "node:path";
 import pc from "picocolors";
-import { createClient, isApiError } from "@rendobar/sdk";
+import { isApiError } from "@rendobar/sdk";
+import { createCliClient } from "../lib/client.js";
 import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, getDashboardBaseUrl } from "../lib/auth.js";
 import { parseFfmpegArgs } from "../lib/parse-ffmpeg-args.js";
 import { shellEscape } from "../lib/shell-escape.js";
@@ -196,7 +197,7 @@ export default defineCommand({
     const clientConfig = cred.type === "apikey"
       ? { apiKey: cred.apiKey, baseUrl }
       : { accessToken: cred.accessToken, baseUrl };
-    const client = createClient(clientConfig);
+    const client = createCliClient(clientConfig);
     const steps = new StepRenderer({ isTTY, quiet: flags.quiet });
 
     const controller = new AbortController();

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -6,7 +6,7 @@
  */
 import { defineCommand } from "citty";
 import pc from "picocolors";
-import { createClient } from "@rendobar/sdk";
+import { createCliClient } from "../lib/client.js";
 import { saveApiKey, saveOAuthCredentials, getConfigDir, openBrowser, CLI_CLIENT_ID, getApiBaseUrl } from "../lib/auth.js";
 const CALLBACK_PORT = 14832;
 const REDIRECT_URI = `http://127.0.0.1:${CALLBACK_PORT}/callback`;
@@ -130,7 +130,7 @@ export default defineCommand({
         process.exit(2);
       }
       try {
-        const client = createClient({ apiKey });
+        const client = createCliClient({ apiKey });
         const state = await client.orgs.current();
         await saveApiKey(apiKey, undefined, { orgName: state.org.name, plan: state.plan.name });
         process.stderr.write(`  ${pc.green("\u2713")} Verified | ${pc.bold(state.org.name)} | ${state.plan.name} plan\n`);
@@ -284,7 +284,7 @@ export default defineCommand({
 
     let identity: { orgName: string; plan: string } | undefined;
     try {
-      const client = createClient({ accessToken, baseUrl });
+      const client = createCliClient({ accessToken, baseUrl });
       const orgState = await client.orgs.current();
       identity = { orgName: orgState.org.name, plan: orgState.plan.name };
       process.stderr.write(`  ${pc.green("\u2713")} Signed in | ${pc.bold(orgState.org.name)} | ${orgState.plan.name} plan\n`);

--- a/src/commands/whoami.ts
+++ b/src/commands/whoami.ts
@@ -3,7 +3,7 @@
  */
 import { defineCommand } from "citty";
 import pc from "picocolors";
-import { createClient } from "@rendobar/sdk";
+import { createCliClient } from "../lib/client.js";
 import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, saveApiKey, saveOAuthCredentials } from "../lib/auth.js";
 
 export default defineCommand({
@@ -31,7 +31,7 @@ export default defineCommand({
       : { accessToken: cred.accessToken, baseUrl };
 
     try {
-      const client = createClient(clientConfig);
+      const client = createCliClient(clientConfig);
       const state = await client.orgs.current();
 
       process.stderr.write(`  ${pc.dim("Org")}       ${pc.bold(state.org.name)}\n`);

--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,0 +1,13 @@
+import { createClient } from "@rendobar/sdk";
+
+/**
+ * Build an SDK client that attributes all CLI traffic as `client=cli`.
+ *
+ * The SDK defaults the `X-Rendobar-Client` header to "sdk"; wrappers are meant
+ * to override it so usage analytics can tell CLI-originated jobs apart from
+ * dashboard/sdk/mcp/n8n traffic. Use this everywhere instead of the raw
+ * `createClient`.
+ */
+export function createCliClient(config: Parameters<typeof createClient>[0] = {}) {
+  return createClient({ ...config, client: "cli" });
+}


### PR DESCRIPTION
SDK 3.3.0 added a `client` option that sets the `X-Rendobar-Client` header for usage attribution (default `"sdk"`). The SDK doc comment calls out that wrappers should override it so their traffic is attributed distinctly.

This wires it into the CLI:

- New `src/lib/client.ts` → `createCliClient(config)` injects `client: "cli"`.
- All four `createClient` call sites (`ffmpeg`, `whoami`, `login` ×2) now go through it, so every CLI-originated job/upload/request is tagged `cli` in usage analytics instead of `sdk`.
- Bumps `@rendobar/sdk` `^3.1.0` → `^3.3.0` (the `client` option landed in 3.3.0; also pulls in 3.2.0 multi-region dispatch reliability into the shipped binary).

Typecheck clean, 134/134 tests pass.
