### PR TITLE
chore(deps): bump @rendobar/sdk to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^1.2.0",
-    "@rendobar/sdk": "^3.3.0",
+    "@rendobar/sdk": "^4.0.0",
     "citty": "^0.2.0",
     "picocolors": "^1.1.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.2.0
         version: 1.7.0
       '@rendobar/sdk':
-        specifier: ^3.3.0
-        version: 3.4.0
+        specifier: ^4.0.0
+        version: 4.0.0
       citty:
         specifier: ^0.2.0
         version: 0.2.2
@@ -140,8 +140,8 @@ packages:
     resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
     engines: {node: '>=22'}
 
-  '@rendobar/sdk@3.4.0':
-    resolution: {integrity: sha512-cgpaoVGxMy35kU9cEesnU/AwSbvX8gRKe0zvNBvjt9X61FvFUXK9sCYWz9BT3LRd47mF+1iY+3/rsQAOLrQFBw==}
+  '@rendobar/sdk@4.0.0':
+    resolution: {integrity: sha512-MUdsTMqwoIBVB+Mq3IH+eNz9dJOisH4s9rB6ZYeVyOAUBh2OLhvTBTbDs7yQejQdi7P7NWt0vTHH93YNm0Rjug==}
     engines: {node: '>=18'}
 
   '@simple-libs/child-process-utils@2.0.0':
@@ -572,7 +572,7 @@ snapshots:
 
   '@conventional-changelog/template@1.2.1': {}
 
-  '@rendobar/sdk@3.4.0':
+  '@rendobar/sdk@4.0.0':
     dependencies:
       partysocket: 1.3.0
     transitivePeerDependencies:


### PR DESCRIPTION
Bumps the bundled `@rendobar/sdk` from `^3.3.0` to `^4.0.0`.

SDK 4.0.0 is a major, but its breaking change (batch-jobs removal) is **not used** by the CLI — it only imports `createClient`, `isApiError`, and the `RendobarClient` type, and already models job output shapes locally.

Verified locally against 4.0.0:
- `tsc --noEmit`: clean
- `bun test`: 134 pass / 0 fail
- `bun build --compile`: builds; `rb --version` and `rb --help` run fine

Supersedes Renovate's pending `renovate/rendobar-sdk-4.x` major PR.