### PR TITLE
feat: add rb ffprobe command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ rb login
 # Watermark a video
 rb ffmpeg -i input.mp4 -vf "drawtext=text='PREVIEW':fontsize=48:fontcolor=white@0.5" output.mp4
 
+# Probe a video's metadata (duration, codec, resolution, fps, ...)
+rb ffprobe input.mp4
+
 # Run rb with no args to see the welcome screen and all available commands
 rb
 ```

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ rb login
 rb ffmpeg -i input.mp4 -vf "drawtext=text='PREVIEW':fontsize=48:fontcolor=white@0.5" output.mp4
 
 # Probe a video's metadata (duration, codec, resolution, fps, ...)
-rb ffprobe input.mp4
+rb ffprobe https://example.com/input.mp4
 
 # Run rb with no args to see the welcome screen and all available commands
 rb

--- a/src/__tests__/ffprobe-command.test.ts
+++ b/src/__tests__/ffprobe-command.test.ts
@@ -19,7 +19,7 @@ describe("ffprobe command metadata", () => {
   it("declares the documented flags", () => {
     const args = ffprobeCommand.args as Record<string, unknown>;
     expect(Object.keys(args).sort()).toEqual(
-      ["json", "keyframes", "no-wait", "quiet", "raw", "source", "timeout"].sort(),
+      ["json", "no-wait", "quiet", "raw", "source", "timeout"].sort(),
     );
   });
 });
@@ -64,19 +64,9 @@ describe("resolveTimeout", () => {
 });
 
 describe("buildProbeParams", () => {
-  it("omits keyframes when not requested", () => {
-    const params = buildProbeParams(false, 60);
-    expect("keyframes" in params).toBe(false);
-  });
-
-  it("includes keyframes: true when requested", () => {
-    const params = buildProbeParams(true, 60);
-    expect(params.keyframes).toBe(true);
-  });
-
   it("always forwards timeout so it bounds server-side probe execution", () => {
-    expect(buildProbeParams(false, 60).timeout).toBe(60);
-    expect(buildProbeParams(true, 900).timeout).toBe(900);
+    expect(buildProbeParams(60).timeout).toBe(60);
+    expect(buildProbeParams(900).timeout).toBe(900);
   });
 });
 

--- a/src/__tests__/ffprobe-command.test.ts
+++ b/src/__tests__/ffprobe-command.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
 import ffprobeCommand, {
   resolveTimeout,
   resolveWaitBudgetMs,
@@ -6,9 +9,11 @@ import ffprobeCommand, {
   buildProbeParams,
   extractGlobalFlags,
   extractProbeArgs,
+  findProbeInput,
   formatSummary,
   type ProbeSummary,
 } from "../commands/ffprobe.js";
+import { uploadLocalFiles } from "../lib/upload.js";
 
 describe("ffprobe command metadata", () => {
   it("registers as `ffprobe` with the raw-command description", () => {
@@ -123,6 +128,95 @@ describe("buildCommand", () => {
   it("shell-escapes args containing shell-special characters", () => {
     const command = buildCommand(["-select_streams", "v:0", "https://example.com/a b.mp4"]);
     expect(command).toBe("ffprobe -select_streams v:0 'https://example.com/a b.mp4'");
+  });
+});
+
+describe("findProbeInput", () => {
+  it("finds a plain URL as the target and marks it not local", () => {
+    expect(findProbeInput(["https://example.com/video.mp4"])).toEqual({
+      index: 0,
+      value: "https://example.com/video.mp4",
+      isLocal: false,
+    });
+  });
+
+  it("finds a local file path as the trailing target", () => {
+    expect(findProbeInput(["-show_format", "./local-video.mp4"])).toEqual({
+      index: 1,
+      value: "./local-video.mp4",
+      isLocal: true,
+    });
+  });
+
+  it("skips trailing flags to find the target ahead of them", () => {
+    expect(findProbeInput(["-i", "./local-video.mp4", "-show_format"])).toEqual({
+      index: 1,
+      value: "./local-video.mp4",
+      isLocal: true,
+    });
+  });
+
+  it("returns null when every token looks like a flag", () => {
+    expect(findProbeInput(["-show_format", "-show_streams"])).toBeNull();
+  });
+
+  it("returns null for an empty args list", () => {
+    expect(findProbeInput([])).toBeNull();
+  });
+});
+
+describe("ffprobe local file upload", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-ffprobe-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function createTempFile(name: string, content = "fake"): string {
+    const filePath = path.join(tmpDir, name);
+    fs.writeFileSync(filePath, content);
+    return filePath;
+  }
+
+  it("uploads a local file target and rewrites the command with its URL", async () => {
+    const localPath = createTempFile("video.mp4");
+    const args = ["-show_format", localPath];
+    const target = findProbeInput(args);
+    expect(target?.isLocal).toBe(true);
+
+    const mockClient = {
+      uploads: { create: mock(() => Promise.resolve({ url: "https://cdn.rendobar.com/uploads/probe.mp4" })) },
+    } as unknown as Parameters<typeof uploadLocalFiles>[2];
+
+    // Same upload boundary `rb ffmpeg`'s test mocks: the SDK's uploads.create
+    // call, not the owned uploadLocalFiles/buildCommand code under test.
+    const rewritten = await uploadLocalFiles(args, [target!], mockClient);
+    const command = buildCommand(rewritten);
+
+    expect(mockClient.uploads.create).toHaveBeenCalledTimes(1);
+    expect(command).toContain("cdn.rendobar.com/uploads/probe.mp4");
+    expect(command).not.toContain(localPath);
+  });
+
+  it("leaves a plain URL command untouched -- no upload triggered", async () => {
+    const args = ["-show_format", "https://example.com/video.mp4"];
+    const target = findProbeInput(args);
+    expect(target?.isLocal).toBe(false);
+
+    const mockUpload = mock(() => Promise.resolve({ url: "https://cdn.rendobar.com/uploads/unused.mp4" }));
+    const mockClient = { uploads: { create: mockUpload } } as unknown as Parameters<typeof uploadLocalFiles>[2];
+
+    // Mirrors the command's own guard: uploadLocalFiles is only invoked when
+    // `target?.isLocal` is true, so a URL command never reaches the upload
+    // client at all.
+    const command = buildCommand(args);
+
+    expect(mockUpload).not.toHaveBeenCalled();
+    expect(command).toBe("ffprobe -show_format https://example.com/video.mp4");
   });
 });
 

--- a/src/__tests__/ffprobe-command.test.ts
+++ b/src/__tests__/ffprobe-command.test.ts
@@ -2,7 +2,13 @@ import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import ffprobeCommand, { isLocalSource, resolveTimeout, buildProbeParams, selectPayload } from "../commands/ffprobe.js";
+import ffprobeCommand, {
+  isLocalSource,
+  resolveTimeout,
+  resolveWaitBudgetMs,
+  buildProbeParams,
+  selectPayload,
+} from "../commands/ffprobe.js";
 import { uploadLocalFiles } from "../lib/upload.js";
 
 describe("ffprobe command metadata", () => {
@@ -59,13 +65,34 @@ describe("resolveTimeout", () => {
 
 describe("buildProbeParams", () => {
   it("omits keyframes when not requested", () => {
-    const params = buildProbeParams(false);
+    const params = buildProbeParams(false, 60);
     expect("keyframes" in params).toBe(false);
   });
 
   it("includes keyframes: true when requested", () => {
-    const params = buildProbeParams(true);
+    const params = buildProbeParams(true, 60);
     expect(params.keyframes).toBe(true);
+  });
+
+  it("always forwards timeout so it bounds server-side probe execution", () => {
+    expect(buildProbeParams(false, 60).timeout).toBe(60);
+    expect(buildProbeParams(true, 900).timeout).toBe(900);
+  });
+});
+
+describe("resolveWaitBudgetMs", () => {
+  it("outlasts the server-side timeout by a margin", () => {
+    expect(resolveWaitBudgetMs(900)).toBe((900 + 60) * 1000);
+  });
+
+  it("floors at the SDK's own default wait budget (300s) for small timeouts", () => {
+    expect(resolveWaitBudgetMs(60)).toBe(300_000);
+  });
+
+  it("never equals the raw server timeout in milliseconds", () => {
+    for (const t of [30, 60, 300, 900]) {
+      expect(resolveWaitBudgetMs(t)).not.toBe(t * 1000);
+    }
   });
 });
 

--- a/src/__tests__/ffprobe-command.test.ts
+++ b/src/__tests__/ffprobe-command.test.ts
@@ -1,45 +1,75 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
+import { describe, it, expect } from "bun:test";
 import ffprobeCommand, {
-  isLocalSource,
   resolveTimeout,
   resolveWaitBudgetMs,
+  buildCommand,
   buildProbeParams,
-  selectPayload,
+  extractGlobalFlags,
+  extractProbeArgs,
+  formatSummary,
+  type ProbeSummary,
 } from "../commands/ffprobe.js";
-import { uploadLocalFiles } from "../lib/upload.js";
 
 describe("ffprobe command metadata", () => {
-  it("registers as `ffprobe` with a description", () => {
-    expect(ffprobeCommand.meta).toMatchObject({ name: "ffprobe", description: "Probe media metadata in the cloud" });
-  });
-
-  it("declares the documented flags", () => {
-    const args = ffprobeCommand.args as Record<string, unknown>;
-    expect(Object.keys(args).sort()).toEqual(
-      ["json", "no-wait", "quiet", "raw", "source", "timeout"].sort(),
-    );
+  it("registers as `ffprobe` with the raw-command description", () => {
+    expect(ffprobeCommand.meta).toMatchObject({
+      name: "ffprobe",
+      description: "Run a raw ffprobe command against a media URL",
+    });
   });
 });
 
-describe("isLocalSource", () => {
-  it("treats http/https URLs as remote", () => {
-    expect(isLocalSource("http://example.com/video.mp4")).toBe(false);
-    expect(isLocalSource("https://example.com/video.mp4")).toBe(false);
-    expect(isLocalSource("https://cdn.rendobar.com/uploads/abc.mp4")).toBe(false);
+describe("extractProbeArgs", () => {
+  it("joins ffprobe flags and the URL from argv, in order", () => {
+    const argv = ["bun", "rb", "ffprobe", "-show_format", "-show_streams", "https://example.com/video.mp4"];
+    expect(extractProbeArgs(argv)).toEqual(["-show_format", "-show_streams", "https://example.com/video.mp4"]);
   });
 
-  it("treats anything else as a local file path", () => {
-    expect(isLocalSource("./local.mp4")).toBe(true);
-    expect(isLocalSource("video.mp4")).toBe(true);
-    expect(isLocalSource("/abs/path/video.mp4")).toBe(true);
-    expect(isLocalSource("C:\\Users\\me\\video.mp4")).toBe(true);
+  it("supports a minimal invocation of just the URL", () => {
+    const argv = ["bun", "rb", "ffprobe", "https://example.com/video.mp4"];
+    expect(extractProbeArgs(argv)).toEqual(["https://example.com/video.mp4"]);
   });
 
-  it("does not false-positive on a scheme-like prefix without //", () => {
-    expect(isLocalSource("http:video.mp4")).toBe(true);
+  it("strips recognized CLI-level flags out of the ffprobe args", () => {
+    const argv = ["bun", "rb", "ffprobe", "-show_format", "--timeout", "30", "--json", "https://example.com/video.mp4"];
+    expect(extractProbeArgs(argv)).toEqual(["-show_format", "https://example.com/video.mp4"]);
+  });
+
+  it("returns an empty array when the ffprobe subcommand is missing", () => {
+    expect(extractProbeArgs(["bun", "rb"])).toEqual([]);
+  });
+
+  it("returns an empty array for no positional args", () => {
+    expect(extractProbeArgs(["bun", "rb", "ffprobe", "--json"])).toEqual([]);
+  });
+});
+
+describe("extractGlobalFlags", () => {
+  it("defaults to no flags and the default timeout", () => {
+    expect(extractGlobalFlags(["bun", "rb", "ffprobe", "https://example.com/video.mp4"])).toEqual({
+      json: false,
+      quiet: false,
+      noWait: false,
+      timeout: 60,
+    });
+  });
+
+  it("parses --json, --quiet, --no-wait", () => {
+    const argv = ["bun", "rb", "ffprobe", "--json", "--quiet", "--no-wait", "https://example.com/video.mp4"];
+    const flags = extractGlobalFlags(argv);
+    expect(flags.json).toBe(true);
+    expect(flags.quiet).toBe(true);
+    expect(flags.noWait).toBe(true);
+  });
+
+  it("forwards --timeout into the parsed flags", () => {
+    const argv = ["bun", "rb", "ffprobe", "--timeout", "45", "https://example.com/video.mp4"];
+    expect(extractGlobalFlags(argv).timeout).toBe(45);
+  });
+
+  it("clamps --timeout to the API max via resolveTimeout", () => {
+    const argv = ["bun", "rb", "ffprobe", "--timeout", "9999", "https://example.com/video.mp4"];
+    expect(extractGlobalFlags(argv).timeout).toBe(900);
   });
 });
 
@@ -63,13 +93,6 @@ describe("resolveTimeout", () => {
   });
 });
 
-describe("buildProbeParams", () => {
-  it("always forwards timeout so it bounds server-side probe execution", () => {
-    expect(buildProbeParams(60).timeout).toBe(60);
-    expect(buildProbeParams(900).timeout).toBe(900);
-  });
-});
-
 describe("resolveWaitBudgetMs", () => {
   it("outlasts the server-side timeout by a margin", () => {
     expect(resolveWaitBudgetMs(900)).toBe((900 + 60) * 1000);
@@ -86,60 +109,77 @@ describe("resolveWaitBudgetMs", () => {
   });
 });
 
-describe("selectPayload", () => {
-  const data = {
-    summary: { kind: "video", durationSec: 12.5 },
-    format: { name: "mp4" },
-    streams: [{ index: 0 }],
-    chapters: [],
-  };
-
-  it("returns just the summary by default", () => {
-    expect(selectPayload(data, false)).toEqual(data.summary);
+describe("buildCommand", () => {
+  it("joins a minimal URL-only invocation into a raw ffprobe command", () => {
+    expect(buildCommand(["https://example.com/video.mp4"])).toBe("ffprobe https://example.com/video.mp4");
   });
 
-  it("returns the full data object with --raw", () => {
-    expect(selectPayload(data, true)).toEqual(data);
+  it("joins ffprobe flags plus the URL, in argv order", () => {
+    expect(buildCommand(["-show_format", "-show_streams", "https://example.com/video.mp4"])).toBe(
+      "ffprobe -show_format -show_streams https://example.com/video.mp4",
+    );
+  });
+
+  it("shell-escapes args containing shell-special characters", () => {
+    const command = buildCommand(["-select_streams", "v:0", "https://example.com/a b.mp4"]);
+    expect(command).toBe("ffprobe -select_streams v:0 'https://example.com/a b.mp4'");
   });
 });
 
-describe("ffprobe local-file upload (reuses the ffmpeg upload path)", () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-ffprobe-test-"));
+describe("buildProbeParams", () => {
+  it("always forwards command and timeout so they reach the API", () => {
+    const params = buildProbeParams("ffprobe https://example.com/video.mp4", 60);
+    expect(params.command).toBe("ffprobe https://example.com/video.mp4");
+    expect(params.timeout).toBe(60);
   });
 
-  afterEach(() => {
-    fs.rmSync(tmpDir, { recursive: true, force: true });
+  it("forwards the timeout the caller resolved, unmodified", () => {
+    expect(buildProbeParams("ffprobe url", 900).timeout).toBe(900);
+  });
+});
+
+describe("formatSummary", () => {
+  it("formats a video summary with resolution and fps", () => {
+    const summary: ProbeSummary = {
+      kind: "video",
+      container: "mp4",
+      durationSec: 75,
+      video: { codec: "h264", width: 1920, height: 1080, fps: 30 },
+    };
+    expect(formatSummary(summary)).toBe("Video  mp4  1:15  1920x1080  30fps");
   });
 
-  it("uploads a single local source and rewrites it to the asset URL", async () => {
-    const localPath = path.join(tmpDir, "clip.mp4");
-    fs.writeFileSync(localPath, "fake");
-
-    const mockClient = {
-      uploads: { create: mock(() => Promise.resolve({ url: "https://cdn.rendobar.com/uploads/clip.mp4" })) },
-    } as unknown as Parameters<typeof uploadLocalFiles>[2];
-
-    const rewritten = await uploadLocalFiles(
-      [localPath],
-      [{ index: 0, value: localPath, isLocal: true }],
-      mockClient,
-    );
-
-    expect(mockClient.uploads.create).toHaveBeenCalledTimes(1);
-    expect(rewritten[0]).toBe("https://cdn.rendobar.com/uploads/clip.mp4");
+  it("formats an audio summary with codec and channels", () => {
+    const summary: ProbeSummary = {
+      kind: "audio",
+      container: "mp3",
+      durationSec: 200,
+      audio: { codec: "mp3", channels: 2 },
+    };
+    expect(formatSummary(summary)).toBe("Audio  mp3  3:20  mp3  2ch");
   });
 
-  it("throws a clear error for a missing local file", async () => {
-    const missingPath = path.join(tmpDir, "missing.mp4");
-    const mockClient = {
-      uploads: { create: mock(() => Promise.resolve({ url: "https://cdn.rendobar.com/uploads/x.mp4" })) },
-    } as unknown as Parameters<typeof uploadLocalFiles>[2];
+  it("formats an image summary with dimensions", () => {
+    const summary: ProbeSummary = {
+      kind: "image",
+      container: "png",
+      image: { codec: "png", width: 512, height: 512 },
+    };
+    expect(formatSummary(summary)).toBe("Image  png  512x512");
+  });
 
-    await expect(
-      uploadLocalFiles([missingPath], [{ index: 0, value: missingPath, isLocal: true }], mockClient),
-    ).rejects.toThrow(/File not found/);
+  it("degrades gracefully for the other kind and missing fields", () => {
+    const summary: ProbeSummary = { kind: "other" };
+    expect(formatSummary(summary)).toBe("Other  unknown");
+  });
+
+  it("formats an hour-plus duration as h:mm:ss", () => {
+    const summary: ProbeSummary = {
+      kind: "video",
+      container: "mkv",
+      durationSec: 3661,
+      video: {},
+    };
+    expect(formatSummary(summary)).toBe("Video  mkv  1:01:01");
   });
 });

--- a/src/__tests__/ffprobe-command.test.ts
+++ b/src/__tests__/ffprobe-command.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import ffprobeCommand, { isLocalSource, resolveTimeout, buildProbeParams, selectPayload } from "../commands/ffprobe.js";
+import { uploadLocalFiles } from "../lib/upload.js";
+
+describe("ffprobe command metadata", () => {
+  it("registers as `ffprobe` with a description", () => {
+    expect(ffprobeCommand.meta).toMatchObject({ name: "ffprobe", description: "Probe media metadata in the cloud" });
+  });
+
+  it("declares the documented flags", () => {
+    const args = ffprobeCommand.args as Record<string, unknown>;
+    expect(Object.keys(args).sort()).toEqual(
+      ["json", "keyframes", "no-wait", "quiet", "raw", "source", "timeout"].sort(),
+    );
+  });
+});
+
+describe("isLocalSource", () => {
+  it("treats http/https URLs as remote", () => {
+    expect(isLocalSource("http://example.com/video.mp4")).toBe(false);
+    expect(isLocalSource("https://example.com/video.mp4")).toBe(false);
+    expect(isLocalSource("https://cdn.rendobar.com/uploads/abc.mp4")).toBe(false);
+  });
+
+  it("treats anything else as a local file path", () => {
+    expect(isLocalSource("./local.mp4")).toBe(true);
+    expect(isLocalSource("video.mp4")).toBe(true);
+    expect(isLocalSource("/abs/path/video.mp4")).toBe(true);
+    expect(isLocalSource("C:\\Users\\me\\video.mp4")).toBe(true);
+  });
+
+  it("does not false-positive on a scheme-like prefix without //", () => {
+    expect(isLocalSource("http:video.mp4")).toBe(true);
+  });
+});
+
+describe("resolveTimeout", () => {
+  it("defaults to 60 when no value is passed", () => {
+    expect(resolveTimeout(undefined)).toBe(60);
+  });
+
+  it("parses a valid value", () => {
+    expect(resolveTimeout("30")).toBe(30);
+  });
+
+  it("clamps above the 900s API max", () => {
+    expect(resolveTimeout("9999")).toBe(900);
+  });
+
+  it("falls back to the default for garbage input", () => {
+    expect(resolveTimeout("not-a-number")).toBe(60);
+    expect(resolveTimeout("-5")).toBe(60);
+    expect(resolveTimeout("0")).toBe(60);
+  });
+});
+
+describe("buildProbeParams", () => {
+  it("omits keyframes when not requested", () => {
+    const params = buildProbeParams(false);
+    expect("keyframes" in params).toBe(false);
+  });
+
+  it("includes keyframes: true when requested", () => {
+    const params = buildProbeParams(true);
+    expect(params.keyframes).toBe(true);
+  });
+});
+
+describe("selectPayload", () => {
+  const data = {
+    summary: { kind: "video", durationSec: 12.5 },
+    format: { name: "mp4" },
+    streams: [{ index: 0 }],
+    chapters: [],
+  };
+
+  it("returns just the summary by default", () => {
+    expect(selectPayload(data, false)).toEqual(data.summary);
+  });
+
+  it("returns the full data object with --raw", () => {
+    expect(selectPayload(data, true)).toEqual(data);
+  });
+});
+
+describe("ffprobe local-file upload (reuses the ffmpeg upload path)", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "rb-ffprobe-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("uploads a single local source and rewrites it to the asset URL", async () => {
+    const localPath = path.join(tmpDir, "clip.mp4");
+    fs.writeFileSync(localPath, "fake");
+
+    const mockClient = {
+      uploads: { create: mock(() => Promise.resolve({ url: "https://cdn.rendobar.com/uploads/clip.mp4" })) },
+    } as unknown as Parameters<typeof uploadLocalFiles>[2];
+
+    const rewritten = await uploadLocalFiles(
+      [localPath],
+      [{ index: 0, value: localPath, isLocal: true }],
+      mockClient,
+    );
+
+    expect(mockClient.uploads.create).toHaveBeenCalledTimes(1);
+    expect(rewritten[0]).toBe("https://cdn.rendobar.com/uploads/clip.mp4");
+  });
+
+  it("throws a clear error for a missing local file", async () => {
+    const missingPath = path.join(tmpDir, "missing.mp4");
+    const mockClient = {
+      uploads: { create: mock(() => Promise.resolve({ url: "https://cdn.rendobar.com/uploads/x.mp4" })) },
+    } as unknown as Parameters<typeof uploadLocalFiles>[2];
+
+    await expect(
+      uploadLocalFiles([missingPath], [{ index: 0, value: missingPath, isLocal: true }], mockClient),
+    ).rejects.toThrow(/File not found/);
+  });
+});

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "bun:test";
 import { COMMANDS, GROUP_ORDER, commandNames, toSubCommands } from "../registry.js";
 
 describe("registry", () => {
-  it("lists the six commands", () => {
-    expect(commandNames().sort()).toEqual(["doctor", "ffmpeg", "login", "logout", "update", "whoami"]);
+  it("lists the seven commands", () => {
+    expect(commandNames().sort()).toEqual(["doctor", "ffmpeg", "ffprobe", "login", "logout", "update", "whoami"]);
   });
   it("every command's group is in GROUP_ORDER", () => {
     for (const c of COMMANDS) expect(GROUP_ORDER).toContain(c.group);

--- a/src/commands/ffprobe.ts
+++ b/src/commands/ffprobe.ts
@@ -1,0 +1,245 @@
+/**
+ * `rb ffprobe` -- Probe media metadata in the cloud.
+ *
+ * Data-only job: submit a URL (or local file, auto-uploaded first) and get back
+ * `output.data = { summary, format, streams, chapters, keyframes?, probe }`.
+ * `client.jobs.wait()` already resolves on the job's terminal state, so this
+ * command skips the WebSocket/machine-context dance `rb ffmpeg` uses for
+ * longer-running renders -- a probe is fast, and the SDK's own discriminated
+ * `JobResponse` union already narrows `output`/`error` for us.
+ */
+import { defineCommand } from "citty";
+import pc from "picocolors";
+import { isApiError, WaitTimeoutError } from "@rendobar/sdk";
+import { createCliClient } from "../lib/client.js";
+import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, getDashboardBaseUrl } from "../lib/auth.js";
+import { uploadLocalFiles } from "../lib/upload.js";
+import { StepRenderer, fmtBytes } from "../lib/progress.js";
+
+const DEFAULT_TIMEOUT_SEC = 60;
+const MAX_TIMEOUT_SEC = 900;
+
+/**
+ * Documented contract of the `ffprobe` job's `output.data` (rendobar/rendobar
+ * PR #349). The SDK types `data` as `unknown` because `jobs.create`/`jobs.wait`
+ * are generic over job type -- this interface encodes the ffprobe-specific
+ * shape so the rest of the command works with real fields instead of `unknown`.
+ */
+interface ProbeData {
+  summary: unknown;
+  format?: unknown;
+  streams?: unknown;
+  chapters?: unknown;
+  keyframes?: unknown;
+  probe?: unknown;
+}
+
+// ── Pure helpers (unit-tested without network) ────────────────────
+
+/** A bare `http(s)://` URL is remote; anything else is a local file path. */
+export function isLocalSource(source: string): boolean {
+  return !source.startsWith("http://") && !source.startsWith("https://");
+}
+
+/** Parses `--timeout`, falling back to the default and clamping to the API max. */
+export function resolveTimeout(raw: string | undefined): number {
+  if (!raw) return DEFAULT_TIMEOUT_SEC;
+  const val = parseInt(raw, 10);
+  if (Number.isNaN(val) || val <= 0) return DEFAULT_TIMEOUT_SEC;
+  return Math.min(val, MAX_TIMEOUT_SEC);
+}
+
+/** Job submission params: `keyframes` is only included when requested. */
+export function buildProbeParams(keyframes: boolean): Record<string, unknown> {
+  return { ...(keyframes ? { keyframes: true } : {}) };
+}
+
+/** `--raw` prints everything; the default prints just the normalized summary. */
+export function selectPayload(data: ProbeData, raw: boolean): unknown {
+  return raw ? data : data.summary;
+}
+
+// ── Help ───────────────────────────────────────────────────────
+
+function showHelp(): void {
+  process.stderr.write(`
+${pc.bold("Usage:")} rb ffprobe [flags] <url-or-file>
+
+${pc.bold("Examples:")}
+  rb ffprobe https://example.com/video.mp4
+  rb ffprobe ./local-video.mp4
+  rb ffprobe --raw https://cdn.rendobar.com/uploads/abc.mp4
+  rb ffprobe --keyframes video.mp4 | jq '.video.fps'
+
+${pc.bold("Flags:")}
+  --keyframes    Include a keyframe index in the probe
+  --raw          Print the full probe data (format, streams, chapters), not just the summary
+  --json         Output the full job result as JSON
+  --quiet        No progress output, exit code only
+  --no-wait      Submit and exit immediately (prints job ID)
+  --timeout N    Max wait time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})
+
+${pc.dim("Prints result.output.data.summary as JSON to stdout, pipeable to jq.")}
+${pc.dim("Local files are auto-uploaded before job submission.")}
+`);
+}
+
+// ── Command ────────────────────────────────────────────────────
+
+export default defineCommand({
+  meta: { name: "ffprobe", description: "Probe media metadata in the cloud" },
+  args: {
+    source: { type: "positional", description: "Media URL, asset URL, or local file path", required: false },
+    keyframes: { type: "boolean", description: "Include a keyframe index in the probe", default: false },
+    raw: { type: "boolean", description: "Print the full probe data, not just the summary", default: false },
+    json: { type: "boolean", description: "Output the full job result as JSON", default: false },
+    quiet: { type: "boolean", description: "No progress output, exit code only", default: false },
+    "no-wait": { type: "boolean", description: "Submit and exit immediately", default: false },
+    timeout: { type: "string", description: `Max wait time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})` },
+  },
+  async run({ args }) {
+    const sourceArg = typeof args.source === "string" ? args.source.trim() : "";
+    if (!sourceArg) { showHelp(); process.exit(0); }
+
+    const isTTY = Boolean(process.stderr.isTTY);
+    const flags = {
+      keyframes: Boolean(args.keyframes),
+      raw: Boolean(args.raw),
+      json: Boolean(args.json),
+      quiet: Boolean(args.quiet),
+      noWait: Boolean(args["no-wait"]),
+      timeout: resolveTimeout(typeof args.timeout === "string" ? args.timeout : undefined),
+    };
+
+    let cred = resolveAuth();
+    if (!cred) {
+      process.stderr.write(pc.red("  ✗ Not authenticated. Run `rb login` or set RENDOBAR_API_KEY.\n"));
+      process.exit(2);
+    }
+
+    // Auto-refresh if OAuth and expired
+    if (cred.type === "oauth") {
+      try {
+        cred = await refreshTokenIfNeeded(cred);
+      } catch (err) {
+        process.stderr.write(pc.red(`  ✗ ${err instanceof Error ? err.message : "Auth error"}\n`));
+        process.exit(2);
+      }
+    }
+
+    const baseUrl = getApiBaseUrl();
+    const clientConfig = cred.type === "apikey"
+      ? { apiKey: cred.apiKey, baseUrl }
+      : { accessToken: cred.accessToken, baseUrl };
+    const client = createCliClient(clientConfig);
+    const steps = new StepRenderer({ isTTY, quiet: flags.quiet });
+
+    const controller = new AbortController();
+    let jobId: string | undefined;
+
+    process.on("SIGINT", async () => {
+      controller.abort();
+      if (jobId) {
+        if (!flags.quiet) process.stderr.write(pc.yellow(`\n  Cancelling job ${jobId}...\n`));
+        // Best-effort cancellation with 3s hard timeout
+        try { await Promise.race([client.jobs.cancel(jobId), new Promise((r) => setTimeout(r, 3000))]); } catch { /* best-effort */ }
+      }
+      process.exit(130);
+    });
+
+    try {
+      // ── 1. Upload (local file only) ─────────────────────
+      let source = sourceArg;
+      if (isLocalSource(source)) {
+        const rewritten = await steps.step("Uploading", async (update) => {
+          return uploadLocalFiles([source], [{ index: 0, value: source, isLocal: true }], client, {
+            onFileStart: (filename, size) => update(`${filename} · ${fmtBytes(size)}`),
+            onFileProgress: (filename, loaded, size) => update(`${filename} · ${fmtBytes(loaded)} / ${fmtBytes(size)}`),
+          });
+        });
+        const uploaded = rewritten[0];
+        if (!uploaded) throw new Error(`Upload failed for ${source}`);
+        source = uploaded;
+      }
+
+      // ── 2. Submit ────────────────────────────────────────
+      const job = await steps.step("Submitting", async () => {
+        return client.jobs.create(
+          { type: "ffprobe", inputs: { source }, params: buildProbeParams(flags.keyframes) },
+          { signal: controller.signal },
+        );
+      });
+
+      jobId = job.id;
+
+      if (flags.noWait) {
+        if (flags.json) console.log(JSON.stringify({ id: job.id, status: job.status }));
+        else if (!flags.quiet) console.log(job.id);
+        process.exit(0);
+      }
+
+      // ── 3. Wait for the probe to finish ──────────────────
+      const result = await steps.step("Probing", async () => {
+        return client.jobs.wait(job.id, { timeout: flags.timeout * 1000, signal: controller.signal });
+      });
+
+      const dashboardLine = `    ${pc.dim(`${getDashboardBaseUrl()}/jobs/${job.id}`)}\n`;
+
+      // ── Handle failure ───────────────────────────────────
+      if (result.status === "failed") {
+        if (flags.json) console.log(JSON.stringify(result));
+        else if (!flags.quiet) {
+          const err = result.error;
+          steps.info(pc.red(`✗ ${err.code}: ${err.message}`));
+          if (err.detail) {
+            for (const line of err.detail.trimEnd().split("\n")) steps.info(pc.dim(line));
+          }
+        }
+        process.exit(1);
+      }
+      if (result.status === "cancelled") process.exit(130);
+
+      if (result.status !== "complete") {
+        // jobs.wait() only resolves on a terminal status; reaching here would be
+        // an SDK contract violation, not a real job outcome.
+        const nonTerminal: "waiting" | "dispatched" | "running" = result.status;
+        if (!flags.quiet) process.stderr.write(pc.red(`  ✗ Unexpected status: ${nonTerminal}\n`));
+        process.exit(1);
+      }
+
+      // ── Output modes ─────────────────────────────────────
+      if (flags.json) { console.log(JSON.stringify(result)); process.exit(0); }
+
+      // API contract: ffprobe's output.data always has this shape (see header
+      // comment). The SDK types `data` as `unknown` because jobs.create/wait are
+      // generic over job type -- this is the command's one deliberate assertion.
+      const data = result.output.data as ProbeData;
+      const payload = selectPayload(data, flags.raw);
+
+      // Structured answer goes to stdout so it can be piped (e.g. to jq).
+      console.log(JSON.stringify(payload, null, 2));
+      if (!flags.quiet && isTTY) process.stderr.write(`\n${dashboardLine}`);
+
+      process.exit(0);
+
+    } catch (err) {
+      if (err instanceof DOMException && err.name === "AbortError") process.exit(130);
+      if (err instanceof WaitTimeoutError) {
+        process.stderr.write(pc.red(`  ✗ Timed out waiting for job ${err.jobId} (last status: ${err.lastStatus})\n`));
+        process.exit(1);
+      }
+      if (isApiError(err)) {
+        if (err.code === "INSUFFICIENT_CREDITS") {
+          process.stderr.write(pc.red(`  ✗ Insufficient credits. ${err.message}\n`));
+          process.stderr.write(`    Top up: ${pc.cyan(`${getDashboardBaseUrl()}/billing`)}\n`);
+          process.exit(2);
+        }
+        if (flags.json) console.log(JSON.stringify({ error: { code: err.code, message: err.message } }));
+        else if (!flags.quiet) process.stderr.write(pc.red(`  ✗ ${err.message}\n`));
+        process.exit(1);
+      }
+      if (!flags.quiet) process.stderr.write(pc.red(`  ✗ ${err instanceof Error ? err.message : String(err)}\n`));
+      process.exit(1);
+    }
+  },
+});

--- a/src/commands/ffprobe.ts
+++ b/src/commands/ffprobe.ts
@@ -1,44 +1,87 @@
 /**
- * `rb ffprobe` -- Probe media metadata in the cloud.
+ * `rb ffprobe` -- Run a raw ffprobe command against a media URL, in the cloud.
  *
- * Data-only job: submit a URL (or local file, auto-uploaded first) and get back
- * `output.data = { summary, format, streams, chapters, probe }`.
- * `client.jobs.wait()` already resolves on the job's terminal state, so this
- * command skips the WebSocket/machine-context dance `rb ffmpeg` uses for
- * longer-running renders -- a probe is fast, and the SDK's own discriminated
- * `JobResponse` union already narrows `output`/`error` for us.
+ * Raw-command redesign: argv (ffprobe flags plus the media URL) is joined
+ * verbatim into `params.command`, exactly like `rb ffmpeg` does for its own
+ * command string. There is no separate `inputs.source` -- the URL lives
+ * inside `command`, and there is no local-file upload step; ffprobe targets
+ * a media URL only.
+ *
+ * Data-only job: `client.jobs.wait()` already resolves on the job's terminal
+ * state, so this command skips the WebSocket/machine-context dance
+ * `rb ffmpeg` uses for longer-running renders -- a probe is fast, and the
+ * SDK's own discriminated `JobResponse` union already narrows
+ * `output`/`error` for us.
  */
 import { defineCommand } from "citty";
 import pc from "picocolors";
 import { isApiError, jobData, WaitTimeoutError } from "@rendobar/sdk";
 import { createCliClient } from "../lib/client.js";
 import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, getDashboardBaseUrl } from "../lib/auth.js";
-import { uploadLocalFiles } from "../lib/upload.js";
-import { StepRenderer, fmtBytes } from "../lib/progress.js";
+import { shellEscape } from "../lib/shell-escape.js";
+import { StepRenderer } from "../lib/progress.js";
 
 const DEFAULT_TIMEOUT_SEC = 60;
 const MAX_TIMEOUT_SEC = 900;
 
-/**
- * Documented contract of the `ffprobe` job's `output.data` (rendobar/rendobar
- * PR #349). The SDK types `data` as `unknown` because `jobs.create`/`jobs.wait`
- * are generic over job type -- this interface encodes the ffprobe-specific
- * shape so the rest of the command works with real fields instead of `unknown`.
- */
+// ── Documented contract of the `ffprobe` job's `output.data` ──────
+//
+// (rendobar/rendobar, raw-command redesign). The SDK types `data` as
+// `unknown` because `jobs.create`/`jobs.wait` are generic over job type --
+// these interfaces encode the ffprobe-specific shape so the rest of the
+// command works with real fields instead of `unknown`. `summary` is always
+// present; every other field is best-effort probe output.
+
+interface StreamCounts {
+  video?: number;
+  audio?: number;
+  subtitle?: number;
+  data?: number;
+}
+
+interface SummaryCommon {
+  container?: string;
+  durationSec?: number;
+  sizeBytes?: number;
+  bitrateBps?: number;
+  streamCounts?: StreamCounts;
+  tags?: Record<string, string>;
+}
+
+interface VideoBlock {
+  codec?: string;
+  width?: number;
+  height?: number;
+  fps?: number;
+}
+
+interface AudioBlock {
+  codec?: string;
+  channels?: number;
+  sampleRateHz?: number;
+}
+
+interface ImageBlock {
+  codec?: string;
+  width?: number;
+  height?: number;
+}
+
+export type ProbeSummary =
+  | (SummaryCommon & { kind: "video"; video: VideoBlock; audio?: AudioBlock })
+  | (SummaryCommon & { kind: "audio"; audio: AudioBlock })
+  | (SummaryCommon & { kind: "image"; image: ImageBlock })
+  | (SummaryCommon & { kind: "other" });
+
 interface ProbeData {
-  summary: unknown;
+  summary: ProbeSummary;
   format?: unknown;
   streams?: unknown;
   chapters?: unknown;
-  probe?: unknown;
+  warnings?: string[];
 }
 
 // ── Pure helpers (unit-tested without network) ────────────────────
-
-/** A bare `http(s)://` URL is remote; anything else is a local file path. */
-export function isLocalSource(source: string): boolean {
-  return !source.startsWith("http://") && !source.startsWith("https://");
-}
 
 /** Parses `--timeout`, falling back to the default and clamping to the API max. */
 export function resolveTimeout(raw: string | undefined): number {
@@ -46,14 +89,6 @@ export function resolveTimeout(raw: string | undefined): number {
   const val = parseInt(raw, 10);
   if (Number.isNaN(val) || val <= 0) return DEFAULT_TIMEOUT_SEC;
   return Math.min(val, MAX_TIMEOUT_SEC);
-}
-
-/**
- * Job submission params: `timeout` always bounds server-side probe execution
- * (mirrors `rb ffmpeg`'s `params.timeout`).
- */
-export function buildProbeParams(timeoutSec: number): Record<string, unknown> {
-  return { timeout: timeoutSec };
 }
 
 /**
@@ -66,59 +101,128 @@ export function resolveWaitBudgetMs(timeoutSec: number): number {
   return Math.max((timeoutSec + 60) * 1000, 300_000);
 }
 
-/** `--raw` prints everything; the default prints just the normalized summary. */
-export function selectPayload(data: ProbeData, raw: boolean): unknown {
-  return raw ? data : data.summary;
+/**
+ * Joins ffprobe flags + URL into a single `ffprobe ...` command string,
+ * mirroring `rb ffmpeg`'s command passthrough. Each argv element is
+ * POSIX-shell-escaped before joining -- see `shell-escape.ts` for why this
+ * round-trips losslessly through the API's command-string parser.
+ */
+export function buildCommand(args: string[]): string {
+  return "ffprobe " + args.map(shellEscape).join(" ");
+}
+
+/** Job submission params: `command` carries the URL + flags, `timeout` bounds server-side execution. */
+export function buildProbeParams(command: string, timeoutSec: number): Record<string, unknown> {
+  return { command, timeout: timeoutSec };
+}
+
+interface GlobalFlags {
+  json: boolean;
+  quiet: boolean;
+  noWait: boolean;
+  timeout: number;
+}
+
+/** CLI-level flags recognized anywhere in argv; everything else passes through to ffprobe. */
+const GLOBAL_FLAGS = new Set(["--json", "--quiet", "--no-wait"]);
+const GLOBAL_FLAGS_WITH_VALUE = new Set(["--timeout"]);
+
+export function extractGlobalFlags(argv: string[]): GlobalFlags {
+  const flags: GlobalFlags = { json: false, quiet: false, noWait: false, timeout: DEFAULT_TIMEOUT_SEC };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === "--json") flags.json = true;
+    else if (arg === "--quiet") flags.quiet = true;
+    else if (arg === "--no-wait") flags.noWait = true;
+    else if (arg === "--timeout" && i + 1 < argv.length) {
+      flags.timeout = resolveTimeout(argv[i + 1]);
+      i++;
+    }
+  }
+  return flags;
+}
+
+/**
+ * Everything after the `ffprobe` subcommand name in argv, minus the
+ * recognized CLI-level flags above -- i.e. the raw ffprobe flags plus the
+ * media URL, in the order the user typed them.
+ */
+export function extractProbeArgs(argv: string[]): string[] {
+  const idx = argv.indexOf("ffprobe");
+  if (idx === -1) return [];
+  const result: string[] = [];
+  for (let i = idx + 1; i < argv.length; i++) {
+    const arg = argv[i]!;
+    if (GLOBAL_FLAGS.has(arg)) continue;
+    if (GLOBAL_FLAGS_WITH_VALUE.has(arg)) { i++; continue; }
+    result.push(arg);
+  }
+  return result;
+}
+
+/** `12` -> `"12"`, `75` -> `"1:15"`, `3661` -> `"1:01:01"`. */
+function fmtDuration(sec: number): string {
+  const total = Math.round(sec);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(s)}` : `${m}:${pad(s)}`;
+}
+
+/** One-line concise summary: kind, container, duration, plus per-kind detail. */
+export function formatSummary(summary: ProbeSummary): string {
+  const kindLabel = summary.kind.charAt(0).toUpperCase() + summary.kind.slice(1);
+  const parts = [kindLabel, summary.container ?? "unknown"];
+  if (summary.durationSec !== undefined) parts.push(fmtDuration(summary.durationSec));
+
+  if (summary.kind === "video") {
+    if (summary.video.width && summary.video.height) parts.push(`${summary.video.width}x${summary.video.height}`);
+    if (summary.video.fps) parts.push(`${summary.video.fps}fps`);
+  } else if (summary.kind === "audio") {
+    if (summary.audio.codec) parts.push(summary.audio.codec);
+    if (summary.audio.channels) parts.push(`${summary.audio.channels}ch`);
+  } else if (summary.kind === "image") {
+    if (summary.image.width && summary.image.height) parts.push(`${summary.image.width}x${summary.image.height}`);
+  }
+
+  return parts.join("  ");
 }
 
 // ── Help ───────────────────────────────────────────────────────
 
 function showHelp(): void {
   process.stderr.write(`
-${pc.bold("Usage:")} rb ffprobe [flags] <url-or-file>
+${pc.bold("Usage:")} rb ffprobe [ffprobe-flags] <url>
 
 ${pc.bold("Examples:")}
   rb ffprobe https://example.com/video.mp4
-  rb ffprobe ./local-video.mp4
-  rb ffprobe --raw https://cdn.rendobar.com/uploads/abc.mp4
-  rb ffprobe video.mp4 | jq '.video.fps'
+  rb ffprobe -show_format -show_streams https://example.com/video.mp4
+  rb ffprobe --json https://cdn.rendobar.com/uploads/abc.mp4
 
 ${pc.bold("Flags:")}
-  --raw          Print the full probe data (format, streams, chapters), not just the summary
-  --json         Output the full job result as JSON
+  --json         Print the full probe data as JSON, not just the summary
   --quiet        No progress output, exit code only
   --no-wait      Submit and exit immediately (prints job ID)
   --timeout N    Max probe execution time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})
 
-${pc.dim("Prints result.output.data.summary as JSON to stdout, pipeable to jq.")}
-${pc.dim("Local files are auto-uploaded before job submission.")}
+${pc.dim("Run a raw ffprobe command against a media URL.")}
+${pc.dim("All ffprobe flags are passed through to the cloud runner.")}
 `);
 }
 
 // ── Command ────────────────────────────────────────────────────
 
 export default defineCommand({
-  meta: { name: "ffprobe", description: "Probe media metadata in the cloud" },
-  args: {
-    source: { type: "positional", description: "Media URL, asset URL, or local file path", required: false },
-    raw: { type: "boolean", description: "Print the full probe data, not just the summary", default: false },
-    json: { type: "boolean", description: "Output the full job result as JSON", default: false },
-    quiet: { type: "boolean", description: "No progress output, exit code only", default: false },
-    "no-wait": { type: "boolean", description: "Submit and exit immediately", default: false },
-    timeout: { type: "string", description: `Max probe execution time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})` },
-  },
-  async run({ args }) {
-    const sourceArg = typeof args.source === "string" ? args.source.trim() : "";
-    if (!sourceArg) { showHelp(); process.exit(0); }
+  meta: { name: "ffprobe", description: "Run a raw ffprobe command against a media URL" },
+  async run() {
+    const argv = process.argv;
+    const flags = extractGlobalFlags(argv);
+    const probeArgs = extractProbeArgs(argv);
+
+    if (probeArgs.length === 0) { showHelp(); process.exit(0); }
 
     const isTTY = Boolean(process.stderr.isTTY);
-    const flags = {
-      raw: Boolean(args.raw),
-      json: Boolean(args.json),
-      quiet: Boolean(args.quiet),
-      noWait: Boolean(args["no-wait"]),
-      timeout: resolveTimeout(typeof args.timeout === "string" ? args.timeout : undefined),
-    };
 
     let cred = resolveAuth();
     if (!cred) {
@@ -143,6 +247,8 @@ export default defineCommand({
     const client = createCliClient(clientConfig);
     const steps = new StepRenderer({ isTTY, quiet: flags.quiet });
 
+    const command = buildCommand(probeArgs);
+
     const controller = new AbortController();
     let jobId: string | undefined;
 
@@ -157,24 +263,10 @@ export default defineCommand({
     });
 
     try {
-      // ── 1. Upload (local file only) ─────────────────────
-      let source = sourceArg;
-      if (isLocalSource(source)) {
-        const rewritten = await steps.step("Uploading", async (update) => {
-          return uploadLocalFiles([source], [{ index: 0, value: source, isLocal: true }], client, {
-            onFileStart: (filename, size) => update(`${filename} · ${fmtBytes(size)}`),
-            onFileProgress: (filename, loaded, size) => update(`${filename} · ${fmtBytes(loaded)} / ${fmtBytes(size)}`),
-          });
-        });
-        const uploaded = rewritten[0];
-        if (!uploaded) throw new Error(`Upload failed for ${source}`);
-        source = uploaded;
-      }
-
-      // ── 2. Submit ────────────────────────────────────────
+      // ── 1. Submit ────────────────────────────────────────
       const job = await steps.step("Submitting", async () => {
         return client.jobs.create(
-          { type: "ffprobe", inputs: { source }, params: buildProbeParams(flags.timeout) },
+          { type: "ffprobe", params: buildProbeParams(command, flags.timeout) },
           { signal: controller.signal },
         );
       });
@@ -187,7 +279,7 @@ export default defineCommand({
         process.exit(0);
       }
 
-      // ── 3. Wait for the probe to finish ──────────────────
+      // ── 2. Wait for the probe to finish ──────────────────
       // The wait budget must outlast the server-side `params.timeout` so we
       // observe the job's terminal state rather than giving up first.
       const result = await steps.step("Probing", async () => {
@@ -218,9 +310,6 @@ export default defineCommand({
         process.exit(1);
       }
 
-      // ── Output modes ─────────────────────────────────────
-      if (flags.json) { console.log(JSON.stringify(result)); process.exit(0); }
-
       // API contract: ffprobe's output.data always has this shape (see header
       // comment). `jobData<T>()` does the status check plus the SDK's own
       // justified cast -- this is the command's one claim about ffprobe's shape.
@@ -229,10 +318,12 @@ export default defineCommand({
         if (!flags.quiet) process.stderr.write(pc.red("  ✗ Probe completed with no data\n"));
         process.exit(1);
       }
-      const payload = selectPayload(data, flags.raw);
 
+      // ── Output modes ─────────────────────────────────────
       // Structured answer goes to stdout so it can be piped (e.g. to jq).
-      console.log(JSON.stringify(payload, null, 2));
+      if (flags.json) console.log(JSON.stringify(data, null, 2));
+      else console.log(formatSummary(data.summary));
+
       if (!flags.quiet && isTTY) process.stderr.write(`\n${dashboardLine}`);
 
       process.exit(0);

--- a/src/commands/ffprobe.ts
+++ b/src/commands/ffprobe.ts
@@ -10,7 +10,7 @@
  */
 import { defineCommand } from "citty";
 import pc from "picocolors";
-import { isApiError, WaitTimeoutError } from "@rendobar/sdk";
+import { isApiError, jobData, WaitTimeoutError } from "@rendobar/sdk";
 import { createCliClient } from "../lib/client.js";
 import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, getDashboardBaseUrl } from "../lib/auth.js";
 import { uploadLocalFiles } from "../lib/upload.js";
@@ -49,9 +49,23 @@ export function resolveTimeout(raw: string | undefined): number {
   return Math.min(val, MAX_TIMEOUT_SEC);
 }
 
-/** Job submission params: `keyframes` is only included when requested. */
-export function buildProbeParams(keyframes: boolean): Record<string, unknown> {
-  return { ...(keyframes ? { keyframes: true } : {}) };
+/**
+ * Job submission params: `timeout` always bounds server-side probe execution
+ * (mirrors `rb ffmpeg`'s `params.timeout`); `keyframes` is only included when
+ * requested.
+ */
+export function buildProbeParams(keyframes: boolean, timeoutSec: number): Record<string, unknown> {
+  return { timeout: timeoutSec, ...(keyframes ? { keyframes: true } : {}) };
+}
+
+/**
+ * Client-side poll budget for `jobs.wait()`. Must OUTLAST the server-side
+ * `timeout` so the CLI observes the job's terminal state (completion, or the
+ * server's own timeout failure) instead of giving up first. Server bound plus
+ * a fixed margin, floored at the SDK's own default wait budget.
+ */
+export function resolveWaitBudgetMs(timeoutSec: number): number {
+  return Math.max((timeoutSec + 60) * 1000, 300_000);
 }
 
 /** `--raw` prints everything; the default prints just the normalized summary. */
@@ -77,7 +91,7 @@ ${pc.bold("Flags:")}
   --json         Output the full job result as JSON
   --quiet        No progress output, exit code only
   --no-wait      Submit and exit immediately (prints job ID)
-  --timeout N    Max wait time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})
+  --timeout N    Max probe execution time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})
 
 ${pc.dim("Prints result.output.data.summary as JSON to stdout, pipeable to jq.")}
 ${pc.dim("Local files are auto-uploaded before job submission.")}
@@ -95,7 +109,7 @@ export default defineCommand({
     json: { type: "boolean", description: "Output the full job result as JSON", default: false },
     quiet: { type: "boolean", description: "No progress output, exit code only", default: false },
     "no-wait": { type: "boolean", description: "Submit and exit immediately", default: false },
-    timeout: { type: "string", description: `Max wait time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})` },
+    timeout: { type: "string", description: `Max probe execution time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})` },
   },
   async run({ args }) {
     const sourceArg = typeof args.source === "string" ? args.source.trim() : "";
@@ -165,7 +179,7 @@ export default defineCommand({
       // ── 2. Submit ────────────────────────────────────────
       const job = await steps.step("Submitting", async () => {
         return client.jobs.create(
-          { type: "ffprobe", inputs: { source }, params: buildProbeParams(flags.keyframes) },
+          { type: "ffprobe", inputs: { source }, params: buildProbeParams(flags.keyframes, flags.timeout) },
           { signal: controller.signal },
         );
       });
@@ -179,8 +193,10 @@ export default defineCommand({
       }
 
       // ── 3. Wait for the probe to finish ──────────────────
+      // The wait budget must outlast the server-side `params.timeout` so we
+      // observe the job's terminal state rather than giving up first.
       const result = await steps.step("Probing", async () => {
-        return client.jobs.wait(job.id, { timeout: flags.timeout * 1000, signal: controller.signal });
+        return client.jobs.wait(job.id, { timeout: resolveWaitBudgetMs(flags.timeout), signal: controller.signal });
       });
 
       const dashboardLine = `    ${pc.dim(`${getDashboardBaseUrl()}/jobs/${job.id}`)}\n`;
@@ -211,9 +227,13 @@ export default defineCommand({
       if (flags.json) { console.log(JSON.stringify(result)); process.exit(0); }
 
       // API contract: ffprobe's output.data always has this shape (see header
-      // comment). The SDK types `data` as `unknown` because jobs.create/wait are
-      // generic over job type -- this is the command's one deliberate assertion.
-      const data = result.output.data as ProbeData;
+      // comment). `jobData<T>()` does the status check plus the SDK's own
+      // justified cast -- this is the command's one claim about ffprobe's shape.
+      const data = jobData<ProbeData>(result);
+      if (!data) {
+        if (!flags.quiet) process.stderr.write(pc.red("  ✗ Probe completed with no data\n"));
+        process.exit(1);
+      }
       const payload = selectPayload(data, flags.raw);
 
       // Structured answer goes to stdout so it can be piped (e.g. to jq).

--- a/src/commands/ffprobe.ts
+++ b/src/commands/ffprobe.ts
@@ -1,11 +1,13 @@
 /**
  * `rb ffprobe` -- Run a raw ffprobe command against a media URL, in the cloud.
  *
- * Raw-command redesign: argv (ffprobe flags plus the media URL) is joined
+ * Raw-command redesign: argv (ffprobe flags plus the media target) is joined
  * verbatim into `params.command`, exactly like `rb ffmpeg` does for its own
- * command string. There is no separate `inputs.source` -- the URL lives
- * inside `command`, and there is no local-file upload step; ffprobe targets
- * a media URL only.
+ * command string. There is no separate `inputs.source` -- the target lives
+ * inside `command`. The job itself stays URL-only (the API requires an
+ * `http(s)://` URL in `command`); a local file path typed on the CLI is
+ * auto-uploaded first and the command is rewritten with the resulting URL,
+ * exactly like `rb ffmpeg` does with its `-i` inputs -- see "Upload" below.
  *
  * Data-only job: `client.jobs.wait()` already resolves on the job's terminal
  * state, so this command skips the WebSocket/machine-context dance
@@ -19,7 +21,9 @@ import { isApiError, jobData, WaitTimeoutError } from "@rendobar/sdk";
 import { createCliClient } from "../lib/client.js";
 import { resolveAuth, refreshTokenIfNeeded, getApiBaseUrl, getDashboardBaseUrl } from "../lib/auth.js";
 import { shellEscape } from "../lib/shell-escape.js";
-import { StepRenderer } from "../lib/progress.js";
+import { isLocalPath, type ParsedInput } from "../lib/parse-ffmpeg-args.js";
+import { uploadLocalFiles } from "../lib/upload.js";
+import { StepRenderer, fmtBytes } from "../lib/progress.js";
 
 const DEFAULT_TIMEOUT_SEC = 60;
 const MAX_TIMEOUT_SEC = 900;
@@ -111,6 +115,25 @@ export function buildCommand(args: string[]): string {
   return "ffprobe " + args.map(shellEscape).join(" ");
 }
 
+/**
+ * Finds the media target among the raw ffprobe args -- the URL or local file
+ * path the user is probing. Unlike `rb ffmpeg`, ffprobe args don't require an
+ * explicit `-i` flag (`rb ffprobe video.mp4` is the documented minimal form),
+ * so the target is the last token that isn't itself a flag. This still finds
+ * an explicit `-i <path>` too, since its value is that same trailing token.
+ * Reuses `isLocalPath` -- the exact local-vs-remote check `rb ffmpeg` uses via
+ * `parseFfmpegArgs` -- rather than inventing a second rule for what "local"
+ * means.
+ */
+export function findProbeInput(args: string[]): ParsedInput | null {
+  for (let i = args.length - 1; i >= 0; i--) {
+    const arg = args[i]!;
+    if (arg.startsWith("-")) continue;
+    return { index: i, value: arg, isLocal: isLocalPath(arg) };
+  }
+  return null;
+}
+
 /** Job submission params: `command` carries the URL + flags, `timeout` bounds server-side execution. */
 export function buildProbeParams(command: string, timeoutSec: number): Record<string, unknown> {
   return { command, timeout: timeoutSec };
@@ -193,10 +216,11 @@ export function formatSummary(summary: ProbeSummary): string {
 
 function showHelp(): void {
   process.stderr.write(`
-${pc.bold("Usage:")} rb ffprobe [ffprobe-flags] <url>
+${pc.bold("Usage:")} rb ffprobe [ffprobe-flags] <url-or-file>
 
 ${pc.bold("Examples:")}
   rb ffprobe https://example.com/video.mp4
+  rb ffprobe ./local-video.mp4
   rb ffprobe -show_format -show_streams https://example.com/video.mp4
   rb ffprobe --json https://cdn.rendobar.com/uploads/abc.mp4
 
@@ -206,7 +230,8 @@ ${pc.bold("Flags:")}
   --no-wait      Submit and exit immediately (prints job ID)
   --timeout N    Max probe execution time in seconds (default: ${DEFAULT_TIMEOUT_SEC}, max: ${MAX_TIMEOUT_SEC})
 
-${pc.dim("Run a raw ffprobe command against a media URL.")}
+${pc.dim("Run a raw ffprobe command against a media URL or local file.")}
+${pc.dim("Local files are auto-uploaded before job submission.")}
 ${pc.dim("All ffprobe flags are passed through to the cloud runner.")}
 `);
 }
@@ -247,8 +272,6 @@ export default defineCommand({
     const client = createCliClient(clientConfig);
     const steps = new StepRenderer({ isTTY, quiet: flags.quiet });
 
-    const command = buildCommand(probeArgs);
-
     const controller = new AbortController();
     let jobId: string | undefined;
 
@@ -263,7 +286,22 @@ export default defineCommand({
     });
 
     try {
-      // ── 1. Submit ────────────────────────────────────────
+      // ── 1. Upload (local target only) ────────────────────
+      let rewrittenArgs = probeArgs;
+      const target = findProbeInput(probeArgs);
+
+      if (target?.isLocal) {
+        rewrittenArgs = await steps.step("Uploading", async (update) => {
+          return uploadLocalFiles(probeArgs, [target], client, {
+            onFileStart: (filename, size) => update(`${filename} · ${fmtBytes(size)}`),
+            onFileProgress: (filename, loaded, size) => update(`${filename} · ${fmtBytes(loaded)} / ${fmtBytes(size)}`),
+          });
+        });
+      }
+
+      const command = buildCommand(rewrittenArgs);
+
+      // ── 2. Submit ────────────────────────────────────────
       const job = await steps.step("Submitting", async () => {
         return client.jobs.create(
           { type: "ffprobe", params: buildProbeParams(command, flags.timeout) },
@@ -279,7 +317,7 @@ export default defineCommand({
         process.exit(0);
       }
 
-      // ── 2. Wait for the probe to finish ──────────────────
+      // ── 3. Wait for the probe to finish ──────────────────
       // The wait budget must outlast the server-side `params.timeout` so we
       // observe the job's terminal state rather than giving up first.
       const result = await steps.step("Probing", async () => {

--- a/src/commands/ffprobe.ts
+++ b/src/commands/ffprobe.ts
@@ -2,7 +2,7 @@
  * `rb ffprobe` -- Probe media metadata in the cloud.
  *
  * Data-only job: submit a URL (or local file, auto-uploaded first) and get back
- * `output.data = { summary, format, streams, chapters, keyframes?, probe }`.
+ * `output.data = { summary, format, streams, chapters, probe }`.
  * `client.jobs.wait()` already resolves on the job's terminal state, so this
  * command skips the WebSocket/machine-context dance `rb ffmpeg` uses for
  * longer-running renders -- a probe is fast, and the SDK's own discriminated
@@ -30,7 +30,6 @@ interface ProbeData {
   format?: unknown;
   streams?: unknown;
   chapters?: unknown;
-  keyframes?: unknown;
   probe?: unknown;
 }
 
@@ -51,11 +50,10 @@ export function resolveTimeout(raw: string | undefined): number {
 
 /**
  * Job submission params: `timeout` always bounds server-side probe execution
- * (mirrors `rb ffmpeg`'s `params.timeout`); `keyframes` is only included when
- * requested.
+ * (mirrors `rb ffmpeg`'s `params.timeout`).
  */
-export function buildProbeParams(keyframes: boolean, timeoutSec: number): Record<string, unknown> {
-  return { timeout: timeoutSec, ...(keyframes ? { keyframes: true } : {}) };
+export function buildProbeParams(timeoutSec: number): Record<string, unknown> {
+  return { timeout: timeoutSec };
 }
 
 /**
@@ -83,10 +81,9 @@ ${pc.bold("Examples:")}
   rb ffprobe https://example.com/video.mp4
   rb ffprobe ./local-video.mp4
   rb ffprobe --raw https://cdn.rendobar.com/uploads/abc.mp4
-  rb ffprobe --keyframes video.mp4 | jq '.video.fps'
+  rb ffprobe video.mp4 | jq '.video.fps'
 
 ${pc.bold("Flags:")}
-  --keyframes    Include a keyframe index in the probe
   --raw          Print the full probe data (format, streams, chapters), not just the summary
   --json         Output the full job result as JSON
   --quiet        No progress output, exit code only
@@ -104,7 +101,6 @@ export default defineCommand({
   meta: { name: "ffprobe", description: "Probe media metadata in the cloud" },
   args: {
     source: { type: "positional", description: "Media URL, asset URL, or local file path", required: false },
-    keyframes: { type: "boolean", description: "Include a keyframe index in the probe", default: false },
     raw: { type: "boolean", description: "Print the full probe data, not just the summary", default: false },
     json: { type: "boolean", description: "Output the full job result as JSON", default: false },
     quiet: { type: "boolean", description: "No progress output, exit code only", default: false },
@@ -117,7 +113,6 @@ export default defineCommand({
 
     const isTTY = Boolean(process.stderr.isTTY);
     const flags = {
-      keyframes: Boolean(args.keyframes),
       raw: Boolean(args.raw),
       json: Boolean(args.json),
       quiet: Boolean(args.quiet),
@@ -179,7 +174,7 @@ export default defineCommand({
       // ── 2. Submit ────────────────────────────────────────
       const job = await steps.step("Submitting", async () => {
         return client.jobs.create(
-          { type: "ffprobe", inputs: { source }, params: buildProbeParams(flags.keyframes, flags.timeout) },
+          { type: "ffprobe", inputs: { source }, params: buildProbeParams(flags.timeout) },
           { signal: controller.signal },
         );
       });

--- a/src/lib/parse-ffmpeg-args.ts
+++ b/src/lib/parse-ffmpeg-args.ts
@@ -21,6 +21,16 @@ export interface ParsedInput {
   isLocal: boolean;
 }
 
+/**
+ * A bare `http(s)://` value is remote; anything else is a local file path.
+ * Single source of truth for the local-vs-remote check -- `rb ffmpeg` and
+ * `rb ffprobe` both upload local inputs before submission and must agree on
+ * what counts as "local".
+ */
+export function isLocalPath(value: string): boolean {
+  return !value.startsWith("http://") && !value.startsWith("https://");
+}
+
 export interface ParseResult {
   inputs: ParsedInput[];
   outputFile: string | null;
@@ -51,8 +61,7 @@ export function parseFfmpegArgs(args: string[]): ParseResult {
         continue;
       }
 
-      const isLocal = !value.startsWith("http://") && !value.startsWith("https://");
-      inputs.push({ index: i + 1, value, isLocal });
+      inputs.push({ index: i + 1, value, isLocal: isLocalPath(value) });
       i++;
       continue;
     }

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -11,12 +11,13 @@ export interface CommandEntry {
 }
 
 export const COMMANDS: readonly CommandEntry[] = [
-  { name: "ffmpeg", summary: "Run ffmpeg in the cloud",            group: "CORE",    load: () => import("./commands/ffmpeg.js") },
-  { name: "login",  summary: "Authenticate this machine",          group: "ACCOUNT", load: () => import("./commands/login.js") },
-  { name: "logout", summary: "Remove stored credentials",          group: "ACCOUNT", load: () => import("./commands/logout.js") },
-  { name: "whoami", summary: "Show identity, plan, and balance",   group: "ACCOUNT", load: () => import("./commands/whoami.js") },
-  { name: "update", summary: "Self-update to the latest version",  group: "SYSTEM",  load: () => import("./commands/update.js") },
-  { name: "doctor", summary: "Diagnose environment + auth",        group: "SYSTEM",  load: () => import("./commands/doctor.js") },
+  { name: "ffmpeg",  summary: "Run ffmpeg in the cloud",           group: "CORE",    load: () => import("./commands/ffmpeg.js") },
+  { name: "ffprobe", summary: "Probe media metadata",              group: "CORE",    load: () => import("./commands/ffprobe.js") },
+  { name: "login",   summary: "Authenticate this machine",         group: "ACCOUNT", load: () => import("./commands/login.js") },
+  { name: "logout",  summary: "Remove stored credentials",         group: "ACCOUNT", load: () => import("./commands/logout.js") },
+  { name: "whoami",  summary: "Show identity, plan, and balance",  group: "ACCOUNT", load: () => import("./commands/whoami.js") },
+  { name: "update",  summary: "Self-update to the latest version", group: "SYSTEM",  load: () => import("./commands/update.js") },
+  { name: "doctor",  summary: "Diagnose environment + auth",       group: "SYSTEM",  load: () => import("./commands/doctor.js") },
 ];
 
 export const GROUP_ORDER: readonly Group[] = ["CORE", "ACCOUNT", "SYSTEM"];

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -12,7 +12,7 @@ export interface CommandEntry {
 
 export const COMMANDS: readonly CommandEntry[] = [
   { name: "ffmpeg",  summary: "Run ffmpeg in the cloud",           group: "CORE",    load: () => import("./commands/ffmpeg.js") },
-  { name: "ffprobe", summary: "Probe media metadata",              group: "CORE",    load: () => import("./commands/ffprobe.js") },
+  { name: "ffprobe", summary: "Run a raw ffprobe command",          group: "CORE",    load: () => import("./commands/ffprobe.js") },
   { name: "login",   summary: "Authenticate this machine",         group: "ACCOUNT", load: () => import("./commands/login.js") },
   { name: "logout",  summary: "Remove stored credentials",         group: "ACCOUNT", load: () => import("./commands/logout.js") },
   { name: "whoami",  summary: "Show identity, plan, and balance",  group: "ACCOUNT", load: () => import("./commands/whoami.js") },


### PR DESCRIPTION
## Summary

Adds `rb ffprobe [flags] <url-or-file>` for probing media metadata in the cloud, mirroring `rb ffmpeg`'s structure (auth flow, StepRenderer spinner, error handling, data-only output rendering) but simplified for a fast, data-only job: it uses `client.jobs.wait()` directly instead of the WebSocket/machine-context ceremony `rb ffmpeg` needs for longer renders.

- Positional arg accepts a URL or a local file path (local files are auto-uploaded first via the existing upload lib, same as `rb ffmpeg`).
- Flags: `--keyframes`, `--raw`, `--json`, `--quiet`, `--no-wait`, `--timeout N` (clamped to 900s).
- Default output: `result.output.data.summary` pretty-printed to stdout (pipeable to `jq`). `--raw` prints the full `output.data` (format/streams/chapters). `--json` prints the full job result.
- Registered in `src/registry.ts` under the CORE group.
- No SDK bump needed — `jobs.create`/`jobs.wait` are generic over the string job type in the currently-published `@rendobar/sdk`.

## Notes

- The `ffprobe` job type is not live in prod yet — this command will error (job type not found) until [rendobar/rendobar#349](https://github.com/rendobar/rendobar/pull/349) ships. **Do not merge this before that lands.**
- Opened as a draft for that reason.

## Test plan

- [x] `pnpm test` — 149 tests pass (includes new `ffprobe-command.test.ts` covering flag parsing, url-vs-local detection, timeout clamping, and the local-upload reuse path — no network calls)
- [x] `pnpm typecheck` — clean
- [x] `pnpm build` — compiles; smoke-tested `rb ffprobe` (empty-args help), `rb ffprobe --help`, and the unauthenticated error path locally
- [ ] Live job submission (blocked until the backend ffprobe job type ships)