### PR TITLE
chore: fix package description, em-dash and stale scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "rendobar-cli",
   "version": "1.10.1",
   "private": true,
-  "description": "Rendobar CLI — serverless video processing from your terminal.",
+  "description": "Rendobar CLI: media processing and AI generation from your terminal.",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Coordinated with [rendobar/rendobar#472](https://github.com/rendobar/rendobar/pull/472), which changes the canonical slogan to "Media processing and AI generation API".

```diff
- Rendobar CLI — serverless video processing from your terminal.
+ Rendobar CLI: media processing and AI generation from your terminal.
```

Two problems in one string:

1. **Em-dash.** Banned site-wide by `writing-style.md`, and `brand-consistency.md` names this exact field with this exact string as its canonical bad example.
2. **Stale scope.** "Video processing" no longer covers the product. Three of the nine live job types (`image.generate`, `image.edit`, `image.upscale`) generate images rather than transform video.

Now follows the brand colon format.