### PR TITLE
chore: sync README to the new brand copy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,17 @@ Critical rules embedded here so you don't need to context-switch:
 (lowercase except in URLs / package names), `https://www.rendobar.com`,
 `http://rendobar.com`, apex page links without a trailing slash.
 
-### `package.json description` — em-dash, sentence case
+### `package.json description` — colon, sentence case
 
-- ✅ `"Rendobar CLI — serverless video processing from your terminal."`
+The em-dash is BANNED. It was the 2024–2025 convention here, but apex
+`writing-style.md` bans it site-wide as an AI-aesthetic tell, and apex
+`brand-consistency.md` names the old string below as its canonical BAD example.
+This section used to require the opposite, which is how the em-dash survived
+until 2026-08-04.
+
+- ✅ `"Rendobar CLI: media processing and AI generation from your terminal."`
+- ❌ `"Rendobar CLI — serverless video processing from your terminal."` (em-dash, and video-only)
 - ❌ `"Rendobar | CLI Tool"` (pipe, title case)
-- ❌ `"Rendobar CLI - serverless..."` (ASCII hyphen instead of em-dash)
 
 ### README + issue templates — trailing slash on apex page links
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <h1 align="center">Rendobar CLI</h1>
 <p align="center">
-  <strong>Serverless video processing from your terminal.</strong><br>
-  Run FFmpeg jobs and burn captions in the cloud with one command.
+  <strong>Media processing and AI generation from your terminal.</strong><br>
+  Run FFmpeg, compose video, burn captions and generate images in the cloud with one command.
 </p>
 <p align="center">
   <a href="https://rendobar.com">Website</a> •
@@ -72,7 +72,7 @@ irm https://rendobar.com/uninstall.ps1 | iex
 
 ### Inspect before running
 
-The install/uninstall scripts are [source-visible in this repo](https://github.com/rendobar/cli/blob/main/install.sh). `rendobar.com/install.sh` redirects here — download and read first if you prefer.
+The install/uninstall scripts are [source-visible in this repo](https://github.com/rendobar/cli/blob/main/install.sh). `rendobar.com/install.sh` redirects here. Download and read it first if you prefer.
 
 ## Quick start
 
@@ -117,7 +117,7 @@ export DO_NOT_TRACK=1      # or RENDOBAR_TELEMETRY=0
 
 ## What is Rendobar?
 
-Rendobar is a serverless media processing platform. Run FFmpeg jobs and burn captions with one API call. Credit-based billing. MCP-native for AI agents.
+Rendobar is a serverless media processing platform. Run FFmpeg, compose video from a timeline, burn captions, compress to a budget, and generate images with one API call. Credit-based billing. MCP-native for AI agents.
 
 - **Website**: https://rendobar.com
 - **Docs**: https://rendobar.com/docs/
@@ -164,4 +164,4 @@ Commit messages must follow [Conventional Commits](https://www.conventionalcommi
 
 ## License
 
-MIT — see [LICENSE](./LICENSE).
+MIT. See [LICENSE](./LICENSE).


### PR DESCRIPTION
Coordinated with [rendobar/rendobar#472](https://github.com/rendobar/rendobar/pull/472).

```diff
- Serverless video processing from your terminal.
- Run FFmpeg jobs and burn captions in the cloud with one command.
+ Media processing and AI generation from your terminal.
+ Run FFmpeg, compose video, burn captions and generate images in the cloud with one command.
```

The "What is Rendobar?" section had the same problem and is updated to match.

Also removes two em-dashes, which `writing-style.md` bans site-wide. README count is now 0.