### PR TITLE
feat: add rb prompt to print the AI integration prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ rb ffmpeg -i input.mp4 -vf "drawtext=text='PREVIEW':fontsize=48:fontcolor=white@
 # Probe a video's metadata (duration, codec, resolution, fps, ...)
 rb ffprobe https://example.com/input.mp4
 
+# Print the AI integration prompt (paste into Claude, ChatGPT, or Cursor)
+rb prompt --copy
+
 # Run rb with no args to see the welcome screen and all available commands
 rb
 ```

--- a/docs/superpowers/specs/2026-08-15-rb-init-design.md
+++ b/docs/superpowers/specs/2026-08-15-rb-init-design.md
@@ -1,0 +1,88 @@
+# `rb init` -- Design Spec
+
+**Date:** 2026-08-15
+**Repo:** `github.com/rendobar/cli`
+**Status:** Draft design. Not scheduled for implementation. `rb prompt` (shipped) is the manual half of this flow; `rb init` is the automated half.
+
+## Problem
+
+Today a developer integrates Rendobar by creating an API key in the dashboard, pasting the AI integration prompt into their coding agent (`rb prompt`), and letting the agent do the wiring. That flow still has two weak points:
+
+1. The API key travels through a human. People paste keys into chats, which puts live secrets in a third party's logs. The prompt tells the agent to refuse pasted keys, but the safest key is one that never enters a conversation at all.
+2. The agent re-derives project setup that a CLI already knows how to do deterministically: stack detection, env file wiring, client scaffolding.
+
+`rb init` closes both gaps: an authenticated, one-command project bootstrap that provisions the key itself and leaves the agent-facing rules behind in the repo.
+
+This follows the precedent set by Clerk's `clerk-init` and Neon's `neon-init` CLIs: an authenticated init command that writes credentials to local env files directly and drops agent rules into the project, so no secret ever rides a chat.
+
+## Command
+
+```
+rb init [--dir <path>] [--yes]
+```
+
+Requires auth (`rb login` or `RENDOBAR_API_KEY`), same resolution order as `rb whoami`. Unauthenticated invocations exit 2 with the standard "Run `rb login`" hint.
+
+## Steps
+
+### 1. Detect the stack
+
+Inspect the target directory, in order: `package.json` (JavaScript/TypeScript, use `@rendobar/sdk`), `requirements.txt` / `pyproject.toml` (Python, REST), `go.mod` (Go, REST). Anything else, or an empty directory: prompt the user to pick (clack prompt, matching `rb login` style). The stack decides which scaffold template is written in step 5.
+
+### 2. Create or reuse an API key
+
+Via the authenticated API:
+
+- List the org's keys. If a key named `cli-init` (or a name the user picks) already exists and the local env file already holds a working key, reuse it.
+- Otherwise create a new key scoped to the org, named after the project directory (e.g. `init-myapp`).
+- The plaintext key is returned exactly once by the API. It goes straight into the env file in step 3 and is never printed, logged, or echoed. This is the core difference from the `rb prompt` flow: the key never passes through a human or a chat.
+
+### 3. Write RENDOBAR_API_KEY to a gitignored env file
+
+- Pick the env file the stack convention expects: `.env.local` (Next.js and most JS), `.env` otherwise. Respect an existing file: append or replace only the `RENDOBAR_API_KEY=` line, preserve everything else byte for byte.
+- Verify the file is gitignored before writing. If it is not, add the pattern to `.gitignore` in the same run and say so. Never write a key into a file git would commit.
+- If a `RENDOBAR_API_KEY` line already exists with a different value, ask before overwriting (`--yes` skips the ask and keeps the existing value).
+
+### 4. Upsert the managed block into AGENTS.md / CLAUDE.md
+
+Write the Rendobar agent rules (the same content `rb prompt` prints, minus the interactive key handling steps that no longer apply because the key is already in env) into the project's agent instruction file:
+
+- Target `AGENTS.md` if present, else `CLAUDE.md` if present, else create `AGENTS.md`.
+- The block is fenced by markers, following the Next.js managed-block convention: content outside the markers is preserved untouched, and the block between them is replaced wholesale on every run, so re-running `rb init` updates stale rules without clobbering the user's own instructions.
+
+```
+<!-- BEGIN:rendobar-agent-rules -->
+...managed content, rewritten on every rb init run...
+<!-- END:rendobar-agent-rules -->
+```
+
+- No markers found: append the block at the end of the file. Markers found: replace the span between them. A BEGIN without an END is an error, not a guess; print the fix and exit.
+
+### 5. Scaffold a minimal client plus a done-check
+
+Stack-appropriate, additive only (never overwrite an existing file):
+
+- JS/TS: install `@rendobar/sdk`, write `rendobar.ts` (or `.js`) exporting a configured client, and `rendobar-check.ts`: submits an ffprobe job on `https://cdn.rendobar.com/assets/examples/sample.mp4`, waits, prints the result. This mirrors the "definition of done" step in the integration prompt.
+- Python/Go: same shape via REST calls against `https://api.rendobar.com` (no version prefix), generated from the same job flow.
+
+The done-check doubles as the smoke test: a 401 means the env file is not being loaded by the runtime, and the check says so.
+
+### 6. Print next steps
+
+Short, actionable, stderr (matching the CLI's output conventions):
+
+- The one command that runs the done-check.
+- Where the key was written and that it is gitignored.
+- That agent rules were installed and where.
+- Pointer to `rb prompt` for driving a coding agent through deeper integration work.
+
+## Non-goals
+
+- No framework-specific integrations (no Next.js route handlers, no queue consumers). The scaffold is a client plus a check, nothing more.
+- No interactive job builder. `rb ffmpeg` and friends already cover that.
+- No telemetry beyond the standard per-command event.
+
+## Open questions
+
+- Key scoping: should init-created keys carry a restricted scope once the API supports scoped keys?
+- Monorepos: which package gets the env file and scaffold when several exist?

--- a/src/__tests__/prompt-command.test.ts
+++ b/src/__tests__/prompt-command.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, mock } from "bun:test";
+import promptCommand, {
+  PROMPT_URL,
+  FALLBACK_PROMPT,
+  resolvePrompt,
+  clipboardCommands,
+} from "../commands/prompt.js";
+
+describe("prompt command metadata", () => {
+  it("registers as `prompt` with the paste-into-your-agent description", () => {
+    expect(promptCommand.meta).toMatchObject({
+      name: "prompt",
+      description: "Print the AI integration prompt (paste into Claude, ChatGPT, or Cursor)",
+    });
+  });
+});
+
+describe("FALLBACK_PROMPT", () => {
+  it("tells the agent to read the key from env, never from the chat", () => {
+    expect(FALLBACK_PROMPT).toContain("RENDOBAR_API_KEY");
+    expect(FALLBACK_PROMPT).toContain("Never ask me to paste the key");
+  });
+
+  it("points the agent at the live job catalog instead of a baked-in list", () => {
+    expect(FALLBACK_PROMPT).toContain("https://api.rendobar.com/jobs/types");
+  });
+
+  it("uses only canonical Rendobar URLs", () => {
+    expect(FALLBACK_PROMPT).toContain("https://rendobar.com");
+    expect(FALLBACK_PROMPT).toContain("https://app.rendobar.com");
+    expect(FALLBACK_PROMPT).not.toContain("www.rendobar.com");
+  });
+});
+
+describe("resolvePrompt", () => {
+  const liveText = "# Add Rendobar to this project\n\nRendobar ... RENDOBAR_API_KEY ...";
+
+  function fetchReturning(status: number, body: string): typeof fetch {
+    return mock(() =>
+      Promise.resolve(new Response(body, { status })),
+    ) as unknown as typeof fetch;
+  }
+
+  it("returns the fetched text when the live copy responds OK", async () => {
+    expect(await resolvePrompt(fetchReturning(200, liveText))).toBe(liveText);
+  });
+
+  it("falls back on a non-2xx response", async () => {
+    expect(await resolvePrompt(fetchReturning(404, "Not Found"))).toBe(FALLBACK_PROMPT);
+  });
+
+  it("falls back on a network error", async () => {
+    const failing = mock(() => Promise.reject(new Error("getaddrinfo ENOTFOUND"))) as unknown as typeof fetch;
+    expect(await resolvePrompt(failing)).toBe(FALLBACK_PROMPT);
+  });
+
+  it("falls back when the body is not the prompt (edge error page)", async () => {
+    expect(await resolvePrompt(fetchReturning(200, "<html>site under maintenance</html>"))).toBe(FALLBACK_PROMPT);
+  });
+
+  it("falls back on an empty body", async () => {
+    expect(await resolvePrompt(fetchReturning(200, "   "))).toBe(FALLBACK_PROMPT);
+  });
+
+  it("requests the canonical prompt URL", async () => {
+    const spy = mock(() => Promise.resolve(new Response(liveText, { status: 200 })));
+    await resolvePrompt(spy as unknown as typeof fetch);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const firstArg = (spy.mock.calls[0] as unknown[])[0];
+    expect(firstArg).toBe(PROMPT_URL);
+    expect(PROMPT_URL).toBe("https://rendobar.com/prompts/integrate.md");
+  });
+});
+
+describe("clipboardCommands", () => {
+  it("uses clip on Windows and pbcopy on macOS", () => {
+    expect(clipboardCommands("win32")).toEqual([{ cmd: "clip", args: [] }]);
+    expect(clipboardCommands("darwin")).toEqual([{ cmd: "pbcopy", args: [] }]);
+  });
+
+  it("tries Wayland then X11 tools on Linux", () => {
+    expect(clipboardCommands("linux").map((c) => c.cmd)).toEqual(["wl-copy", "xclip", "xsel"]);
+  });
+});

--- a/src/__tests__/registry.test.ts
+++ b/src/__tests__/registry.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from "bun:test";
 import { COMMANDS, GROUP_ORDER, commandNames, toSubCommands } from "../registry.js";
 
 describe("registry", () => {
-  it("lists the ten commands", () => {
-    expect(commandNames().sort()).toEqual(["doctor", "edit", "ffmpeg", "ffprobe", "generate", "login", "logout", "telemetry", "update", "whoami"]);
+  it("lists the eleven commands", () => {
+    expect(commandNames().sort()).toEqual(["doctor", "edit", "ffmpeg", "ffprobe", "generate", "login", "logout", "prompt", "telemetry", "update", "whoami"]);
   });
   it("every command's group is in GROUP_ORDER", () => {
     for (const c of COMMANDS) expect(GROUP_ORDER).toContain(c.group);

--- a/src/commands/prompt.ts
+++ b/src/commands/prompt.ts
@@ -1,0 +1,144 @@
+/**
+ * `rb prompt` -- Print the AI integration prompt.
+ *
+ * The prompt is the copy-paste text a user hands to Claude, ChatGPT, or Cursor
+ * to integrate Rendobar into their codebase. The live copy at
+ * https://rendobar.com/prompts/integrate.md is fetched first (short timeout) so
+ * users always get the latest text; the bundled fallback below covers offline
+ * and air-gapped runs.
+ */
+import { spawn } from "node:child_process";
+import { defineCommand } from "citty";
+import pc from "picocolors";
+
+export const PROMPT_URL = "https://rendobar.com/prompts/integrate.md";
+const FETCH_TIMEOUT_MS = 3_000;
+
+/**
+ * Bundled fallback copy of the integration prompt.
+ *
+ * Canonical source: `packages/shared/src/constants/integration-prompt.ts` in
+ * the rendobar/rendobar monorepo (`buildIntegrationPrompt()`, constants
+ * interpolated). When the template changes there, re-render it and paste the
+ * output here verbatim.
+ */
+export const FALLBACK_PROMPT = `# Add Rendobar to this project
+
+You are integrating Rendobar (https://rendobar.com), a media processing and AI generation API, into this codebase. These instructions supersede anything you remember about Rendobar. Work from the live sources below, not from memory.
+
+Live sources of truth:
+- Job catalog: GET https://api.rendobar.com/jobs/types (public, no auth). Per-type parameters: GET https://api.rendobar.com/jobs/types/{type}/schema
+- OpenAPI 3.1 spec: https://api.rendobar.com/openapi.json
+- Capability map: https://rendobar.com/llms.txt
+- Docs text for AI: https://rendobar.com/docs/llms-full.txt (human docs at https://rendobar.com/docs)
+- Error reference: https://rendobar.com/docs/support/errors
+
+API key rules, follow exactly:
+- I created an API key in the Rendobar dashboard. Ask me to put it in this project's env as RENDOBAR_API_KEY, in a gitignored env file, and wait for my confirmation before running anything that calls the API.
+- Never ask me to paste the key into this chat. Never print, log, or commit it. Never put it in client-side code.
+
+Step 0, detect the stack before writing code:
+- Inspect the project (package.json, requirements.txt, go.mod, composer.json, Gemfile). JavaScript or TypeScript: use the official SDK, @rendobar/sdk. Anything else: call the REST API directly using the OpenAPI spec above. Same endpoints, same shapes.
+- If the project is empty, ask me which stack I want.
+
+Steps (SDK path; mirror with plain HTTP on the REST path):
+1. Install @rendobar/sdk. Create the client with createClient({ apiKey: process.env.RENDOBAR_API_KEY }).
+2. Read the live job catalog and pick the job types this project needs from what it actually lists. Do not invent job types or parameters.
+3. Submit with client.jobs.create({ type, inputs, params }). Media inputs are URLs. Pass an idempotencyKey anywhere a retry could double-submit.
+4. Results: client.jobs.wait(job.id) is fine for scripts. For a production server, use webhooks: ask me to add an endpoint at https://app.rendobar.com/webhooks, then verify signatures with verifyWebhook from "@rendobar/sdk/webhooks".
+5. Handle errors by machine code (error.code), never message text. INSUFFICIENT_CREDITS: tell me to top up at https://app.rendobar.com/billing. RATE_LIMITED: retry with backoff. Full list in the error reference.
+6. Local files: upload through the assets flow (POST https://api.rendobar.com/assets, documented in the docs), then pass the returned asset url as the job input.
+7. Definition of done: a runnable check that submits an ffprobe job on https://cdn.rendobar.com/assets/examples/sample.mp4 and prints the result. Show me the one command that runs it. A 401 means the key is not reaching the process env.
+
+Hard rules:
+- The API base is https://api.rendobar.com with no version prefix. There is no batch endpoint. One job produces one output.
+- Additive changes only. Do not refactor or remove unrelated code.
+- When something is ambiguous, choose the smallest default that keeps the app compiling and tell me what you chose. Ask me only when it is a product decision.
+
+If I am talking to you inside an MCP-capable client (Claude, Cursor, and others), also offer to connect Rendobar's MCP server for running jobs in conversation: https://api.rendobar.com/mcp over OAuth, or npx -y @rendobar/mcp with the key read from env. That is separate from the codebase integration above.`;
+
+/**
+ * Fetch the live prompt, falling back to the bundled copy on any failure:
+ * network error, timeout, non-2xx, or a body that is clearly not the prompt
+ * (e.g. an HTML error page from a misconfigured edge).
+ */
+export async function resolvePrompt(fetchImpl: typeof fetch = fetch): Promise<string> {
+  try {
+    const res = await fetchImpl(PROMPT_URL, {
+      headers: { Accept: "text/markdown, text/plain" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return FALLBACK_PROMPT;
+    const text = (await res.text()).trim();
+    // Sanity gate: the real prompt always names the brand and the env var.
+    if (text.length === 0 || !text.includes("Rendobar") || !text.includes("RENDOBAR_API_KEY")) {
+      return FALLBACK_PROMPT;
+    }
+    return text;
+  } catch {
+    return FALLBACK_PROMPT;
+  }
+}
+
+/** Native clipboard writers to try, in order, for a platform. */
+export function clipboardCommands(platform: NodeJS.Platform): Array<{ cmd: string; args: string[] }> {
+  switch (platform) {
+    case "win32":
+      return [{ cmd: "clip", args: [] }];
+    case "darwin":
+      return [{ cmd: "pbcopy", args: [] }];
+    default:
+      // Linux and BSDs: Wayland first, then the two X11 staples.
+      return [
+        { cmd: "wl-copy", args: [] },
+        { cmd: "xclip", args: ["-selection", "clipboard"] },
+        { cmd: "xsel", args: ["--clipboard", "--input"] },
+      ];
+  }
+}
+
+function tryClipboardCommand(cmd: string, args: string[], text: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    try {
+      const child = spawn(cmd, args, { stdio: ["pipe", "ignore", "ignore"], windowsHide: true });
+      child.on("error", () => resolve(false)); // spawn failure (command not found)
+      child.on("close", (code) => resolve(code === 0));
+      child.stdin.on("error", () => {}); // EPIPE if the tool exits early; close handler decides
+      child.stdin.write(text);
+      child.stdin.end();
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/** Copy text to the system clipboard via native tools. Never throws. */
+export async function copyToClipboard(text: string, platform: NodeJS.Platform = process.platform): Promise<boolean> {
+  for (const { cmd, args } of clipboardCommands(platform)) {
+    if (await tryClipboardCommand(cmd, args, text)) return true;
+  }
+  return false;
+}
+
+export default defineCommand({
+  meta: {
+    name: "prompt",
+    description: "Print the AI integration prompt (paste into Claude, ChatGPT, or Cursor)",
+  },
+  args: {
+    copy: { type: "boolean", description: "Also copy the prompt to the clipboard", default: false },
+  },
+  async run({ args }) {
+    const prompt = await resolvePrompt();
+    process.stdout.write(prompt + "\n");
+
+    if (args.copy) {
+      const copied = await copyToClipboard(prompt);
+      if (copied) {
+        process.stderr.write(`  ${pc.green("✓")} Copied to clipboard.\n`);
+      } else {
+        process.stderr.write(`  ${pc.yellow("!")} Could not copy to clipboard (no clipboard tool found). The prompt is printed above.\n`);
+      }
+    }
+  },
+});

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -15,6 +15,7 @@ export const COMMANDS: readonly CommandEntry[] = [
   { name: "ffprobe",   summary: "Run a raw ffprobe command",             group: "CORE",    load: () => import("./commands/ffprobe.js") },
   { name: "generate",  summary: "Generate an image from a text prompt",  group: "CORE",    load: () => import("./commands/generate.js") },
   { name: "edit",      summary: "Edit an image from a text instruction", group: "CORE",    load: () => import("./commands/edit.js") },
+  { name: "prompt",    summary: "Print the AI integration prompt",       group: "CORE",    load: () => import("./commands/prompt.js") },
   { name: "login",     summary: "Authenticate this machine",            group: "ACCOUNT", load: () => import("./commands/login.js") },
   { name: "logout",    summary: "Remove stored credentials",            group: "ACCOUNT", load: () => import("./commands/logout.js") },
   { name: "whoami",    summary: "Show identity, plan, and balance",     group: "ACCOUNT", load: () => import("./commands/whoami.js") },


### PR DESCRIPTION
## What

Adds `rb prompt`, printing the Rendobar AI integration prompt to stdout so users can paste it into Claude, ChatGPT, or Cursor.

- Primary source: fetches https://rendobar.com/prompts/integrate.md at runtime (3s timeout). Falls back to a bundled copy on network failure, non-2xx, or a body that is clearly not the prompt. The URL 404s today, so the fallback carries the command until the apex page ships; the fetch-first order means the live copy wins automatically once it exists.
- Bundled fallback is the rendered output of the canonical template in the monorepo (`packages/shared/src/constants/integration-prompt.ts`), with a comment pointing future syncs at that file.
- `--copy` also copies to the clipboard via native tools (clip / pbcopy / wl-copy, xclip, xsel). On failure it prints a note to stderr and still prints the prompt.
- Registered in `src/registry.ts` (CORE group), which drives subcommand routing, the unknown-command guard, and the welcome screen. README quick start gains one line.

Also adds a design spec for a future `rb init` command (`docs/superpowers/specs/2026-08-15-rb-init-design.md`, docs commit, no code): authenticated project bootstrap that provisions the API key into a gitignored env file directly and upserts a managed agent-rules block, following the clerk-init / neon-init precedent. Design only, not scheduled.

## Test plan

- `pnpm test`: 230 pass (18 new: metadata, fallback content markers, resolvePrompt fetch/fallback matrix, clipboard command mapping)
- `pnpm typecheck`: clean
- Smoke: `bun run src/main.ts prompt --copy` prints the full prompt to stdout, exit 0, clipboard populated on Windows; with the live URL 404ing this exercises the fallback path end to end