### PR TITLE
fix: request the current scope vocabulary at login

### DIFF
--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -200,7 +200,13 @@ export default defineCommand({
       client_id: CLI_CLIENT_ID,
       redirect_uri: REDIRECT_URI,
       response_type: "code",
-      scope: "openid media:full offline_access",
+      // Must match what the rendobar-cli client is registered with, in
+      // packages/db/seeds/cli-oauth-client.sql. `media:full` was retired with
+      // the scope vocabulary and now expands to nothing, so requesting it still
+      // completed the flow and returned a token carrying zero scopes: login
+      // reported success and every call after it answered 403.
+      scope:
+        "openid offline_access jobs:write assets:write webhooks:write billing:read orgs:read",
       code_challenge: codeChallenge,
       code_challenge_method: "S256",
       state,


### PR DESCRIPTION
`rb login` asked for `openid media:full offline_access`. `media:full` was retired with the scope vocabulary and now expands to **no scopes at all**, so the flow still completed and handed back a token carrying nothing: login reported success and every call after it answered 403.

A silent total failure rather than a refused login, which is the worse of the two.

Nobody is affected today: the grants that held the alias were revoked when it was retired, and there are zero live CLI consents. The next `rb login` would have hit it.

## The set

What the CLI actually calls, and nothing more: `jobs:write`, `assets:write`, `webhooks:write`, `billing:read`, `orgs:read`, plus `openid` and `offline_access`.

It never touches `/api-keys`, so it does not ask for `keys:write`. That matters more here than elsewhere because the `rendobar-cli` client is registered with `skip_consent`, meaning whatever it asks for is granted with no screen for anyone to review.

## Coordination

The matching server change shipped to production in rendobar/rendobar#630, which updates the seeded client's registered scopes. `authorize` validates the request against those, so the two have to agree. The server side is already live, so this is safe to merge and release whenever.