### PR TITLE
fix: report the CLI version in the client header

### DIFF
--- a/src/lib/client.ts
+++ b/src/lib/client.ts
@@ -1,13 +1,19 @@
 import { createClient } from "@rendobar/sdk";
+import { VERSION } from "../generated/version.js";
 
 /**
- * Build an SDK client that attributes all CLI traffic as `client=cli`.
+ * Build an SDK client that attributes all CLI traffic as `cli/<version>`.
  *
  * The SDK defaults the `X-Rendobar-Client` header to "sdk"; wrappers are meant
  * to override it so usage analytics can tell CLI-originated jobs apart from
  * dashboard/sdk/mcp/n8n traffic. Use this everywhere instead of the raw
  * `createClient`.
+ *
+ * The version half matters as much as the name: without it a bug report can say
+ * a job came from the CLI but not which build, and this CLI self-updates, so
+ * the installed version is exactly the thing nobody can tell you. VERSION is
+ * generated from package.json at build time, so it cannot drift.
  */
 export function createCliClient(config: Parameters<typeof createClient>[0] = {}) {
-  return createClient({ ...config, client: "cli" });
+  return createClient({ ...config, client: `cli/${VERSION}` });
 }


### PR DESCRIPTION
Last of an audit of client identification across every Rendobar client.

## The gap

The CLI sent a bare `cli`. A bug report could say traffic came from the CLI but
never **which build** — and that matters more here than anywhere else, because
**the CLI self-updates**, so the installed version is exactly the thing nobody
can tell you after the fact.

## Every client now agrees

| Client | Sends | |
|---|---|---|
| SDK | `sdk/5.10.0` | already correct |
| Activepieces | `activepieces/0.2.0` | already correct |
| MCP | `mcp/1.11.0` | rendobar/mcp#141 — was masquerading as `sdk` |
| n8n | `n8n/0.5.0` | rendobar/n8n-nodes-rendobar#16 |
| **CLI** | **`cli/1.12.2`** | this PR |

## No drift risk

`VERSION` is already generated from `package.json` at build time and used in
four other places, so there is no new constant to keep in sync.

## Checks

- 230 tests pass, typecheck clean