### PR TITLE
docs: tell agents the schema endpoint describes inputs too

### DIFF
--- a/src/commands/prompt.ts
+++ b/src/commands/prompt.ts
@@ -27,7 +27,7 @@ export const FALLBACK_PROMPT = `# Add Rendobar to this project
 You are integrating Rendobar (https://rendobar.com), a media processing and AI generation API, into this codebase. These instructions supersede anything you remember about Rendobar. Work from the live sources below, not from memory.
 
 Live sources of truth:
-- Job catalog: GET https://api.rendobar.com/jobs/types (public, no auth). Per-type parameters: GET https://api.rendobar.com/jobs/types/{type}/schema
+- Job catalog: GET https://api.rendobar.com/jobs/types (public, no auth). Per-type parameters AND the media each type reads: GET https://api.rendobar.com/jobs/types/{type}/schema (the \`inputs\` object names each media input, whether it takes a URL or a list, and whether the type accepts any filename)
 - OpenAPI 3.1 spec: https://api.rendobar.com/openapi.json
 - Capability map: https://rendobar.com/llms.txt
 - Docs text for AI: https://rendobar.com/docs/llms-full.txt (human docs at https://rendobar.com/docs)


### PR DESCRIPTION
Mirrors rendobar/rendobar#651, which adds an `inputs` descriptor to
`GET /jobs/types/{type}/schema`.

The CLI **embeds** the integration prompt rather than fetching it, so it drifts
silently unless edited on the same day as the canonical copy in
`packages/shared/src/constants/integration-prompt.ts`.

The endpoint was described as *"per-type parameters"*. That was true and is now
incomplete: the same endpoint describes the media a job reads, so an agent
following this prompt would keep hardcoding media inputs it could have
discovered.

Docs copy also updated in rendobar/docs.

## Checks

- 230 tests, typecheck clean