### PR TITLE
fix: treat storage:// and asset:// inputs as remote, not local files

### DIFF
--- a/src/__tests__/parse-ffmpeg-args.test.ts
+++ b/src/__tests__/parse-ffmpeg-args.test.ts
@@ -14,6 +14,11 @@ describe("parseFfmpegArgs", () => {
     expect(result.inputs[0]!.isLocal).toBe(true);
   });
 
+  it("treats storage:// and asset:// references as remote, not local files", () => {
+    const result = parseFfmpegArgs(["-i", "storage://demo-bucket/raw/clip.mp4", "-i", "asset://asset_abc123", "output.mp4"]);
+    expect(result.inputs.map((i) => i.isLocal)).toEqual([false, false]);
+  });
+
   it("handles multiple inputs", () => {
     const result = parseFfmpegArgs(["-i", "./video.mp4", "-i", "./audio.mp3", "output.mp4"]);
     expect(result.inputs).toHaveLength(2);

--- a/src/lib/parse-ffmpeg-args.ts
+++ b/src/lib/parse-ffmpeg-args.ts
@@ -22,13 +22,19 @@ export interface ParsedInput {
 }
 
 /**
- * A bare `http(s)://` value is remote; anything else is a local file path.
+ * Values the API fetches or resolves itself: a URL, a file in a connected
+ * bucket (`storage://`), or an uploaded asset (`asset://`).
+ */
+const REMOTE_PREFIXES = ["http://", "https://", "storage://", "asset://"];
+
+/**
+ * Anything without a remote prefix is a local file path.
  * Single source of truth for the local-vs-remote check -- `rb ffmpeg` and
  * `rb ffprobe` both upload local inputs before submission and must agree on
  * what counts as "local".
  */
 export function isLocalPath(value: string): boolean {
-  return !value.startsWith("http://") && !value.startsWith("https://");
+  return !REMOTE_PREFIXES.some((prefix) => value.startsWith(prefix));
 }
 
 export interface ParseResult {


### PR DESCRIPTION
`rb ffmpeg -i storage://demo-bucket/raw/clip.mp4 ...` failed with `File not found: storage://demo-bucket/raw/clip.mp4`, because `isLocalPath` only counted `http://` and `https://` as remote. Anything else was treated as a path on disk and uploaded.

`storage://` (a file in a connected bucket) and `asset://` (an uploaded asset) are resolved by the API, so the CLI now passes them through unchanged. `rb ffprobe` and `rb edit --images` use the same check and get the same fix.

**Merge after** the API storage feature (rendobar/rendobar#682) is deployed to production. Until then the API does not accept these URIs in a command.

Test plan
- [x] New parser test: `storage://` and `asset://` inputs are `isLocal: false`
- [x] `pnpm test` (231 pass), `pnpm typecheck`